### PR TITLE
feat(extensions): add link preview extension with rich preview cards

### DIFF
--- a/apps/chrome-extension/src/inject-widget.ts
+++ b/apps/chrome-extension/src/inject-widget.ts
@@ -21,4 +21,4 @@ try {
 } catch { /* already registered */ }
 
 // Expose for popup's executeScript(world:"MAIN") calls
-(window as Record<string, unknown>).__chativa = { chatStore };
+(window as unknown as Record<string, unknown>).__chativa = { chatStore };

--- a/apps/chrome-extension/tsconfig.json
+++ b/apps/chrome-extension/tsconfig.json
@@ -16,6 +16,7 @@
     "paths": {
       "@chativa/core": ["../../packages/core/src/index.ts"],
       "@chativa/ui": ["../../packages/ui/src/index.ts"],
+      "@chativa/genui": ["../../packages/genui/src/index.ts"],
       "@chativa/connector-dummy": ["../../packages/connector-dummy/src/index.ts"]
     }
   },

--- a/apps/sandbox/src/main.ts
+++ b/apps/sandbox/src/main.ts
@@ -1,8 +1,9 @@
-import { ConnectorRegistry } from "@chativa/core";
+import { ConnectorRegistry, ExtensionRegistry, LinkPreviewExtension } from "@chativa/core";
 import { DummyConnector } from "@chativa/connector-dummy";
 import { GenUIRegistry } from "@chativa/genui";
 import { WeatherWidget } from "./components/WeatherWidget";
 import { AIAppointmentForm } from "./components/AIForm";
+import type { LinkMetadata } from "@chativa/ui";
 
 // Register connector BEFORE UI loads so connectedCallback can find it
 const connector = new DummyConnector({ replyDelay: 500 });
@@ -12,6 +13,62 @@ ConnectorRegistry.register(connector);
 GenUIRegistry.register("weather", WeatherWidget);
 GenUIRegistry.register("genui-appointment-form", AIAppointmentForm as unknown as typeof HTMLElement);
 
+// Install link preview extension by default
+ExtensionRegistry.install(new LinkPreviewExtension({ maxUrlsPerMessage: 3 }));
+
+// Mock metadata fetcher for sandbox demos
+const mockMetadata: Record<string, LinkMetadata> = {
+  "https://github.com": {
+    title: "GitHub: Let's build from here",
+    description: "GitHub is where over 100 million developers shape the future of software, together.",
+    image: "https://github.githubassets.com/images/modules/site/social-cards/github-social.png",
+    domain: "github.com",
+  },
+  "https://www.youtube.com/watch?v=dQw4w9WgXcQ": {
+    title: "Rick Astley - Never Gonna Give You Up (Official Music Video)",
+    description: 'The official video for "Never Gonna Give You Up" by Rick Astley.',
+    image: "https://i.ytimg.com/vi/dQw4w9WgXcQ/maxresdefault.jpg",
+    domain: "youtube.com",
+  },
+  "https://lit.dev": {
+    title: "Lit - A simple library for building fast, lightweight web components",
+    description: "Lit is a simple library for building fast, lightweight web components.",
+    image: "https://lit.dev/images/logo.svg",
+    domain: "lit.dev",
+  },
+  "https://developer.mozilla.org": {
+    title: "MDN Web Docs",
+    description: "The MDN Web Docs site provides information about Open Web technologies.",
+    image: "https://developer.mozilla.org/mdn-social-share.cd6c4a5a.png",
+    domain: "developer.mozilla.org",
+  },
+  "https://example.com": {
+    title: "Example Domain",
+    description: "This domain is for use in illustrative examples in documents.",
+    domain: "example.com",
+  },
+};
+
+const metadataFetcher = async (url: string): Promise<LinkMetadata> => {
+  // Try exact match first
+  if (mockMetadata[url]) return mockMetadata[url];
+
+  // Try base URL match
+  try {
+    const urlObj = new URL(url);
+    const baseUrl = `${urlObj.protocol}//${urlObj.host}${urlObj.pathname}`;
+    if (mockMetadata[baseUrl]) return mockMetadata[baseUrl];
+
+    // Fallback: return domain-only metadata
+    return {
+      domain: urlObj.hostname,
+      title: urlObj.hostname,
+    };
+  } catch {
+    return { domain: url };
+  }
+};
+
 // Expose inject helper for sandbox demo buttons
 (window as unknown as Record<string, unknown>).chativaInject = connector.injectMessage.bind(connector);
 
@@ -19,6 +76,9 @@ GenUIRegistry.register("genui-appointment-form", AIAppointmentForm as unknown as
 (window as unknown as Record<string, unknown>).chativaGenUI = (command: string) => {
   connector.triggerGenUI(command);
 };
+
+// Expose metadata fetcher for link preview cards
+(window as unknown as Record<string, unknown>).chativaMetadataFetcher = metadataFetcher;
 
 // Dynamic import ensures custom elements are defined after registration
 import("@chativa/ui");

--- a/apps/sandbox/src/sandbox/SandboxControls.ts
+++ b/apps/sandbox/src/sandbox/SandboxControls.ts
@@ -10,6 +10,7 @@ import {
 
 import "./sections/AppearanceSection";
 import "./sections/ConnectorSection";
+import "./sections/ExtensionsSection";
 import "./sections/FeaturesSection";
 import "./sections/MessagesSection";
 import "./sections/GenUISection";
@@ -21,6 +22,7 @@ import "./sections/ConfigSection";
 type TabId =
   | "appearance"
   | "connector"
+  | "extensions"
   | "features"
   | "messages"
   | "genui"
@@ -95,6 +97,12 @@ const TABS: TabDef[] = [
     label: "Connector",
     icon: svg`<path d="M9 2v6m6-6v6"/><rect x="6" y="8" width="12" height="6" rx="1"/><path d="M12 14v8"/>`,
     docPath: "connectors/overview.md",
+  },
+  {
+    id: "extensions",
+    label: "Extensions",
+    icon: svg`<rect x="3" y="3" width="8" height="8" rx="1"/><rect x="13" y="3" width="8" height="8" rx="1"/><rect x="3" y="13" width="8" height="8" rx="1"/><path d="M17 13v4a1 1 0 0 1-1 1h-4"/><path d="M13 19h4"/><path d="M15 17v4"/>`,
+    docPath: "extensions.md",
   },
   {
     id: "features",
@@ -536,6 +544,9 @@ export class SandboxControls extends LitElement {
             </div>
             <div class="tab-pane ${this._activeTab === "connector" ? "active" : ""}">
               <sandbox-connector-section></sandbox-connector-section>
+            </div>
+            <div class="tab-pane ${this._activeTab === "extensions" ? "active" : ""}">
+              <sandbox-extensions-section></sandbox-extensions-section>
             </div>
             <div class="tab-pane ${this._activeTab === "features" ? "active" : ""}">
               <sandbox-features-section></sandbox-features-section>

--- a/apps/sandbox/src/sandbox/sections/ExtensionsSection.ts
+++ b/apps/sandbox/src/sandbox/sections/ExtensionsSection.ts
@@ -1,0 +1,244 @@
+import { LitElement, html, css, nothing } from "lit";
+import { customElement, state } from "lit/decorators.js";
+import { ExtensionRegistry, LinkPreviewExtension, type LinkPreviewExtensionOptions } from "@chativa/core";
+import { sectionStyles } from "../sandboxShared";
+
+interface ExtensionConfig {
+  id: string;
+  name: string;
+  description: string;
+  installed: boolean;
+  options: LinkPreviewExtensionOptions;
+}
+
+@customElement("sandbox-extensions-section")
+export class ExtensionsSection extends LitElement {
+  static override styles = [
+    sectionStyles,
+    css`
+      .extension-card {
+        background: #f8fafc;
+        border: 1px solid #e2e8f0;
+        border-radius: 8px;
+        padding: 12px;
+        margin-bottom: 10px;
+      }
+      .extension-header {
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        margin-bottom: 8px;
+      }
+      .extension-name {
+        font-size: 0.875rem;
+        font-weight: 600;
+        color: #0f172a;
+      }
+      .extension-desc {
+        font-size: 0.75rem;
+        color: #64748b;
+        margin-bottom: 10px;
+        line-height: 1.4;
+      }
+      .toggle-switch {
+        position: relative;
+        width: 44px;
+        height: 24px;
+        background: #cbd5e1;
+        border-radius: 12px;
+        cursor: pointer;
+        transition: background 0.2s;
+        flex-shrink: 0;
+      }
+      .toggle-switch.active {
+        background: #4f46e5;
+      }
+      .toggle-switch::after {
+        content: "";
+        position: absolute;
+        top: 2px;
+        left: 2px;
+        width: 20px;
+        height: 20px;
+        background: white;
+        border-radius: 50%;
+        transition: transform 0.2s;
+      }
+      .toggle-switch.active::after {
+        transform: translateX(20px);
+      }
+      .option-row {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        margin-top: 8px;
+        padding-top: 8px;
+        border-top: 1px solid #e2e8f0;
+      }
+      .option-label {
+        font-size: 0.75rem;
+        color: #475569;
+        font-weight: 500;
+      }
+      .option-input {
+        width: 60px;
+        padding: 4px 8px;
+        border: 1px solid #cbd5e1;
+        border-radius: 6px;
+        font-size: 0.75rem;
+        text-align: center;
+      }
+      .option-input:focus {
+        outline: none;
+        border-color: #4f46e5;
+      }
+      .variant-group {
+        display: flex;
+        gap: 3px;
+        background: #f1f5f9;
+        border-radius: 7px;
+        padding: 2px;
+      }
+      .variant-btn {
+        padding: 4px 10px;
+        border: none;
+        border-radius: 5px;
+        background: transparent;
+        font-size: 0.7rem;
+        font-weight: 500;
+        color: #64748b;
+        cursor: pointer;
+        transition: all 0.15s;
+        font-family: inherit;
+      }
+      .variant-btn:hover { color: #0f172a; }
+      .variant-btn.active {
+        background: white;
+        color: #4f46e5;
+        font-weight: 600;
+        box-shadow: 0 1px 3px rgba(0, 0, 0, 0.09);
+      }
+    `,
+  ];
+
+  @state() private _extensions: ExtensionConfig[] = [
+    {
+      id: "link-preview",
+      name: "Link Preview",
+      description: "Extracts URLs from messages and displays rich preview cards. Supports compact and expanded variants.",
+      installed: false,
+      options: {
+        maxUrlsPerMessage: 3,
+        defaultVariant: "compact",
+      },
+    },
+  ];
+
+  override connectedCallback() {
+    super.connectedCallback();
+    this._syncInstalledState();
+  }
+
+  private _syncInstalledState() {
+    this._extensions = this._extensions.map((ext) => ({
+      ...ext,
+      installed: ExtensionRegistry.has(ext.id),
+    }));
+  }
+
+  private _toggleExtension(ext: ExtensionConfig) {
+    if (ext.installed) {
+      ExtensionRegistry.uninstall(ext.id);
+      ext.installed = false;
+    } else {
+      this._installExtension(ext);
+      ext.installed = true;
+    }
+    this.requestUpdate();
+  }
+
+  private _installExtension(ext: ExtensionConfig) {
+    if (ext.id === "link-preview") {
+      ExtensionRegistry.install(new LinkPreviewExtension(ext.options));
+    }
+  }
+
+  private _updateMaxUrls(ext: ExtensionConfig, value: string) {
+    const numValue = parseInt(value, 10);
+    if (isNaN(numValue) || numValue < 1) return;
+
+    ext.options.maxUrlsPerMessage = numValue;
+    this._reinstallIfActive(ext);
+  }
+
+  private _updateVariant(ext: ExtensionConfig, variant: "compact" | "expanded") {
+    ext.options.defaultVariant = variant;
+    this._reinstallIfActive(ext);
+  }
+
+  private _reinstallIfActive(ext: ExtensionConfig) {
+    if (ext.installed) {
+      ExtensionRegistry.uninstall(ext.id);
+      this._installExtension(ext);
+    }
+    this.requestUpdate();
+  }
+
+  render() {
+    return html`
+      <div class="section-header">
+        <span class="section-label">Extensions</span>
+      </div>
+      <div class="section-body">
+        ${this._extensions.map(
+          (ext) => html`
+            <div class="extension-card">
+              <div class="extension-header">
+                <div>
+                  <div class="extension-name">${ext.name}</div>
+                  <div class="extension-desc">${ext.description}</div>
+                </div>
+                <div
+                  class="toggle-switch ${ext.installed ? "active" : ""}"
+                  @click=${() => this._toggleExtension(ext)}
+                ></div>
+              </div>
+              ${ext.installed
+                ? html`
+                    <div class="option-row">
+                      <span class="option-label">Max URLs per message</span>
+                      <input
+                        type="number"
+                        class="option-input"
+                        .value=${String(ext.options.maxUrlsPerMessage)}
+                        min="1"
+                        max="10"
+                        @change=${(e: Event) =>
+                          this._updateMaxUrls(
+                            ext,
+                            (e.target as HTMLInputElement).value
+                          )}
+                      />
+                    </div>
+                    <div class="option-row">
+                      <span class="option-label">Default variant</span>
+                      <div class="variant-group">
+                        <button
+                          class="variant-btn ${ext.options.defaultVariant === "compact" ? "active" : ""}"
+                          @click=${() => this._updateVariant(ext, "compact")}
+                        >Compact</button>
+                        <button
+                          class="variant-btn ${ext.options.defaultVariant === "expanded" ? "active" : ""}"
+                          @click=${() => this._updateVariant(ext, "expanded")}
+                        >Expanded</button>
+                      </div>
+                    </div>
+                  `
+                : nothing}
+            </div>
+          `
+        )}
+      </div>
+    `;
+  }
+}

--- a/apps/sandbox/src/sandbox/sections/MessagesSection.ts
+++ b/apps/sandbox/src/sandbox/sections/MessagesSection.ts
@@ -8,6 +8,22 @@ const DEMO_MESSAGES: Array<{ label: string; msg: Record<string, unknown> }> = [
     msg: { type: "text", data: { text: "Hello! This is a **text** message with _markdown_ support." } },
   },
   {
+    label: "🔗 Link Preview",
+    msg: { type: "text", data: { text: "Check out this link: https://github.com" } },
+  },
+  {
+    label: "🔗 Expanded Preview",
+    msg: { type: "text", data: { text: "Watch this: https://www.youtube.com/watch?v=dQw4w9WgXcQ", preview: "expanded" } },
+  },
+  {
+    label: "🔗 Multiple Links",
+    msg: { type: "text", data: { text: "Here are some useful resources:\n- https://lit.dev\n- https://developer.mozilla.org" } },
+  },
+  {
+    label: "🔗 No Preview",
+    msg: { type: "text", data: { text: "Hidden preview: https://github.com", preview: false } },
+  },
+  {
     label: "⚡ Quick Reply",
     msg: {
       type: "quick-reply",

--- a/packages/connector-dummy/src/DummyConnector.ts
+++ b/packages/connector-dummy/src/DummyConnector.ts
@@ -142,10 +142,17 @@ export class DummyConnector implements IConnector {
       // (double-tick) — paired with ChatEngine's "sent" flip on send (single-tick).
       this.statusHandler?.(message.id, "read" as MessageStatus);
       const replyId = `dummy-reply-${Date.now()}`;
+      
+      // If user sent a URL, include a link in the reply for preview demo
+      const hasUrl = /https?:\/\//i.test(text);
+      const replyText = hasUrl
+        ? `Echo: ${text}\n\nHere's a related resource: https://example.com`
+        : `Echo: ${text}`;
+      
       this.messageHandler?.({
         id: replyId,
         type: "text",
-        data: { text: `Echo: ${text}` },
+        data: { text: replyText },
         timestamp: Date.now(),
       });
     }, this.replyDelay);

--- a/packages/core/src/application/extensions/LinkPreviewExtension.ts
+++ b/packages/core/src/application/extensions/LinkPreviewExtension.ts
@@ -1,0 +1,62 @@
+import type { IExtension, ExtensionContext } from "../../domain/ports/IExtension";
+import type { IncomingMessage } from "../../domain/entities/Message";
+
+const URL_REGEX = /https?:\/\/[^\s<>\]'"()]+/gi;
+
+export type PreviewVariant = "compact" | "expanded";
+
+export interface LinkPreviewExtensionOptions {
+  urlExtractor?: (text: string) => string[];
+  maxUrlsPerMessage?: number;
+  defaultVariant?: PreviewVariant;
+}
+
+function defaultUrlExtractor(text: string): string[] {
+  const matches = text.match(URL_REGEX);
+  if (!matches) return [];
+  return [...new Set(matches.map((u) => u.replace(/[.,;:!?)]+$/, "")))];
+}
+
+export class LinkPreviewExtension implements IExtension {
+  readonly name = "link-preview";
+  readonly version = "1.0.0";
+
+  private readonly _extractor: (text: string) => string[];
+  private readonly _maxUrls: number;
+  private readonly _defaultVariant: PreviewVariant;
+
+  constructor(options: LinkPreviewExtensionOptions = {}) {
+    this._extractor = options.urlExtractor ?? defaultUrlExtractor;
+    this._maxUrls = options.maxUrlsPerMessage ?? 3;
+    this._defaultVariant = options.defaultVariant ?? "compact";
+  }
+
+  install(context: ExtensionContext): void {
+    context.onAfterReceive((msg: IncomingMessage) => {
+      if (msg.type !== "text") return msg;
+
+      const preview = msg.data?.preview;
+      if (preview === false) return msg;
+
+      const text = String(msg.data?.text ?? "");
+      if (!text) return msg;
+
+      let urls = this._extractor(text);
+      if (urls.length === 0) return msg;
+
+      if (urls.length > this._maxUrls) {
+        urls = urls.slice(0, this._maxUrls);
+      }
+
+      const variant: PreviewVariant =
+        preview === "expanded" ? "expanded" : this._defaultVariant;
+
+      return {
+        ...msg,
+        data: { ...msg.data, urls, previewVariant: variant },
+      };
+    });
+  }
+
+  uninstall(): void {}
+}

--- a/packages/core/src/application/extensions/__tests__/LinkPreviewExtension.test.ts
+++ b/packages/core/src/application/extensions/__tests__/LinkPreviewExtension.test.ts
@@ -1,0 +1,149 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { LinkPreviewExtension } from "../LinkPreviewExtension";
+import { ExtensionRegistry } from "../../registries/ExtensionRegistry";
+import type { IncomingMessage } from "../../../domain/entities/Message";
+
+function makeMessage(text: string, type = "text"): IncomingMessage {
+  return { id: "1", type, data: { text } };
+}
+
+describe("LinkPreviewExtension", () => {
+  beforeEach(() => {
+    ExtensionRegistry.clear();
+  });
+
+  it("extracts a single URL from incoming text", () => {
+    ExtensionRegistry.install(new LinkPreviewExtension());
+    const result = ExtensionRegistry.runAfterReceive(
+      makeMessage("Check this: https://example.com")
+    );
+    expect(result?.data.urls).toEqual(["https://example.com"]);
+  });
+
+  it("extracts multiple URLs", () => {
+    ExtensionRegistry.install(new LinkPreviewExtension());
+    const result = ExtensionRegistry.runAfterReceive(
+      makeMessage("See https://a.com and https://b.com")
+    );
+    expect(result?.data.urls).toEqual(["https://a.com", "https://b.com"]);
+  });
+
+  it("deduplicates identical URLs", () => {
+    ExtensionRegistry.install(new LinkPreviewExtension());
+    const result = ExtensionRegistry.runAfterReceive(
+      makeMessage("https://a.com https://a.com")
+    );
+    expect(result?.data.urls).toEqual(["https://a.com"]);
+  });
+
+  it("strips trailing punctuation from URLs", () => {
+    ExtensionRegistry.install(new LinkPreviewExtension());
+    const result = ExtensionRegistry.runAfterReceive(
+      makeMessage("Visit https://example.com.")
+    );
+    expect(result?.data.urls).toEqual(["https://example.com"]);
+  });
+
+  it("limits URLs to maxUrlsPerMessage", () => {
+    ExtensionRegistry.install(new LinkPreviewExtension({ maxUrlsPerMessage: 2 }));
+    const result = ExtensionRegistry.runAfterReceive(
+      makeMessage("https://a.com https://b.com https://c.com")
+    );
+    expect(result?.data.urls).toEqual(["https://a.com", "https://b.com"]);
+  });
+
+  it("does not modify messages without URLs", () => {
+    ExtensionRegistry.install(new LinkPreviewExtension());
+    const result = ExtensionRegistry.runAfterReceive(makeMessage("Hello world"));
+    expect(result?.data.urls).toBeUndefined();
+  });
+
+  it("ignores non-text messages", () => {
+    ExtensionRegistry.install(new LinkPreviewExtension());
+    const msg: IncomingMessage = {
+      id: "1",
+      type: "image",
+      data: { text: "https://example.com" },
+    };
+    const result = ExtensionRegistry.runAfterReceive(msg);
+    expect(result?.data.urls).toBeUndefined();
+  });
+
+  it("accepts a custom URL extractor", () => {
+    const customExtractor = (text: string) =>
+      text.includes("SPECIAL") ? ["https://custom.com"] : [];
+
+    ExtensionRegistry.install(
+      new LinkPreviewExtension({ urlExtractor: customExtractor })
+    );
+    const result = ExtensionRegistry.runAfterReceive(
+      makeMessage("SPECIAL link here")
+    );
+    expect(result?.data.urls).toEqual(["https://custom.com"]);
+  });
+
+  it("preserves existing message data fields", () => {
+    ExtensionRegistry.install(new LinkPreviewExtension());
+    const msg: IncomingMessage = {
+      id: "1",
+      type: "text",
+      data: { text: "https://example.com", custom: "value" },
+    };
+    const result = ExtensionRegistry.runAfterReceive(msg);
+    expect(result?.data.custom).toBe("value");
+    expect(result?.data.urls).toEqual(["https://example.com"]);
+  });
+
+  it("handles http URLs", () => {
+    ExtensionRegistry.install(new LinkPreviewExtension());
+    const result = ExtensionRegistry.runAfterReceive(
+      makeMessage("http://insecure.com/page")
+    );
+    expect(result?.data.urls).toEqual(["http://insecure.com/page"]);
+  });
+
+  it("handles empty text", () => {
+    ExtensionRegistry.install(new LinkPreviewExtension());
+    const result = ExtensionRegistry.runAfterReceive(makeMessage(""));
+    expect(result?.data.urls).toBeUndefined();
+  });
+
+  it("skips URL extraction when preview is false", () => {
+    ExtensionRegistry.install(new LinkPreviewExtension());
+    const msg: IncomingMessage = {
+      id: "1",
+      type: "text",
+      data: { text: "https://example.com", preview: false },
+    };
+    const result = ExtensionRegistry.runAfterReceive(msg);
+    expect(result?.data.urls).toBeUndefined();
+  });
+
+  it("sets previewVariant to expanded when preview is 'expanded'", () => {
+    ExtensionRegistry.install(new LinkPreviewExtension());
+    const msg: IncomingMessage = {
+      id: "1",
+      type: "text",
+      data: { text: "https://example.com", preview: "expanded" },
+    };
+    const result = ExtensionRegistry.runAfterReceive(msg);
+    expect(result?.data.urls).toEqual(["https://example.com"]);
+    expect(result?.data.previewVariant).toBe("expanded");
+  });
+
+  it("defaults previewVariant to compact", () => {
+    ExtensionRegistry.install(new LinkPreviewExtension());
+    const result = ExtensionRegistry.runAfterReceive(
+      makeMessage("https://example.com")
+    );
+    expect(result?.data.previewVariant).toBe("compact");
+  });
+
+  it("uses defaultVariant option when set to expanded", () => {
+    ExtensionRegistry.install(new LinkPreviewExtension({ defaultVariant: "expanded" }));
+    const result = ExtensionRegistry.runAfterReceive(
+      makeMessage("https://example.com")
+    );
+    expect(result?.data.previewVariant).toBe("expanded");
+  });
+});

--- a/packages/core/src/application/index.ts
+++ b/packages/core/src/application/index.ts
@@ -17,3 +17,5 @@ export type { ChativaContext } from "./ChativaContext";
 export { createChativaContext } from "./createChativaContext";
 export { applyGlobalSettings } from "./ChativaSettings";
 export type { ChativaSettings } from "./ChativaSettings";
+export { LinkPreviewExtension } from "./extensions/LinkPreviewExtension";
+export type { LinkPreviewExtensionOptions, PreviewVariant } from "./extensions/LinkPreviewExtension";

--- a/packages/ui/src/chat-ui/DefaultTextMessage.ts
+++ b/packages/ui/src/chat-ui/DefaultTextMessage.ts
@@ -5,6 +5,8 @@ import { marked } from "marked";
 import { t } from "i18next";
 import i18next from "../i18n/i18n";
 import { MessageTypeRegistry, chatStore, type MessageSender, type MessageStatus } from "@chativa/core";
+import type { LinkMetadataFetcher } from "./LinkPreviewCard";
+import "./LinkPreviewCard";
 
 
 @customElement("default-text-message")
@@ -219,6 +221,13 @@ export class DefaultTextMessage extends LitElement {
       cursor: default;
       opacity: 0.7;
     }
+
+    .link-previews {
+      display: flex;
+      flex-direction: column;
+      gap: 6px;
+      margin-top: 4px;
+    }
   `;
 
   @property({ type: Object }) messageData: Record<string, unknown> = {};
@@ -228,6 +237,7 @@ export class DefaultTextMessage extends LitElement {
   /** When true the avatar is invisible (still occupies space for alignment). */
   @property({ type: Boolean }) hideAvatar = false;
   @property({ type: String }) status: MessageStatus = "sent";
+  @property({ type: Function }) metadataFetcher: LinkMetadataFetcher | null = null;
 
   @state() private _feedback: "like" | "dislike" | null = null;
 
@@ -353,6 +363,26 @@ export class DefaultTextMessage extends LitElement {
     `;
   }
 
+  private _renderLinkPreviews() {
+    const urls = this.messageData?.urls as string[] | undefined;
+    if (!urls || urls.length === 0) return nothing;
+
+    const previewVariant = (this.messageData?.previewVariant as string) ?? "compact";
+    const fetcher = this.metadataFetcher ?? (window as unknown as Record<string, unknown>).chativaMetadataFetcher as LinkMetadataFetcher | undefined;
+
+    return html`
+      <div class="link-previews">
+        ${urls.map((url) => html`
+          <link-preview-card
+            .url=${url}
+            variant=${previewVariant}
+            .metadataFetcher=${fetcher ?? null}
+          ></link-preview-card>
+        `)}
+      </div>
+    `;
+  }
+
   render() {
     const isUser = this.sender === "user";
     const raw = String(this.messageData?.text ?? "");
@@ -375,6 +405,7 @@ export class DefaultTextMessage extends LitElement {
         ${isUser && showUserAvatar ? this._renderUserAvatar(avatarCfg?.user) : nothing}
         <div class="content">
           <div class="bubble">${bubbleContent}</div>
+          ${this._renderLinkPreviews()}
           ${!isUser ? html`
             <div class="feedback ${this._effectiveFeedback ? "active" : ""}">
               <button

--- a/packages/ui/src/chat-ui/LinkPreviewCard.ts
+++ b/packages/ui/src/chat-ui/LinkPreviewCard.ts
@@ -1,0 +1,359 @@
+import { LitElement, html, css, nothing } from "lit";
+import { customElement, property, state } from "lit/decorators.js";
+
+export interface LinkMetadata {
+  title?: string;
+  description?: string;
+  image?: string;
+  favicon?: string;
+  domain?: string;
+}
+
+export type LinkMetadataFetcher = (url: string) => Promise<LinkMetadata>;
+export type PreviewVariant = "compact" | "expanded";
+
+const cache = new Map<string, LinkMetadata>();
+
+function extractDomain(url: string): string {
+  try {
+    return new URL(url).hostname;
+  } catch {
+    return url;
+  }
+}
+
+function getFaviconUrl(url: string): string {
+  try {
+    const u = new URL(url);
+    return `https://www.google.com/s2/favicons?domain=${u.hostname}&sz=32`;
+  } catch {
+    return "";
+  }
+}
+
+@customElement("link-preview-card")
+export class LinkPreviewCard extends LitElement {
+  static override styles = css`
+    :host {
+      display: block;
+    }
+
+    :host([variant="compact"]) {
+      max-width: 320px;
+    }
+
+    :host([variant="expanded"]) {
+      max-width: 100%;
+    }
+
+    a {
+      display: flex;
+      border: 1px solid #e2e8f0;
+      border-radius: 12px;
+      overflow: hidden;
+      text-decoration: none;
+      color: inherit;
+      background: #ffffff;
+      transition: box-shadow 0.2s, transform 0.15s;
+    }
+
+    :host([variant="compact"]) a {
+      flex-direction: row;
+    }
+
+    :host([variant="expanded"]) a {
+      flex-direction: row;
+    }
+
+    a:hover {
+      box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
+      transform: translateY(-1px);
+    }
+
+    .preview-image {
+      object-fit: cover;
+      flex-shrink: 0;
+      background: #f1f5f9;
+    }
+
+    :host([variant="compact"]) .preview-image {
+      width: 80px;
+      min-height: 80px;
+    }
+
+    :host([variant="expanded"]) .preview-image {
+      width: 120px;
+      min-height: 120px;
+    }
+
+    .preview-body {
+      display: flex;
+      flex-direction: column;
+      gap: 4px;
+      min-width: 0;
+      flex: 1;
+    }
+
+    :host([variant="compact"]) .preview-body {
+      padding: 10px 12px;
+    }
+
+    :host([variant="expanded"]) .preview-body {
+      padding: 12px 16px;
+    }
+
+    .preview-domain {
+      display: flex;
+      align-items: center;
+      gap: 6px;
+      color: #64748b;
+    }
+
+    :host([variant="compact"]) .preview-domain {
+      font-size: 0.7rem;
+    }
+
+    :host([variant="expanded"]) .preview-domain {
+      font-size: 0.75rem;
+    }
+
+    .preview-domain img {
+      border-radius: 3px;
+    }
+
+    :host([variant="compact"]) .preview-domain img {
+      width: 14px;
+      height: 14px;
+    }
+
+    :host([variant="expanded"]) .preview-domain img {
+      width: 16px;
+      height: 16px;
+    }
+
+    .preview-title {
+      font-weight: 600;
+      color: #1e293b;
+      line-height: 1.3;
+      display: -webkit-box;
+      -webkit-box-orient: vertical;
+      overflow: hidden;
+    }
+
+    :host([variant="compact"]) .preview-title {
+      font-size: 0.8rem;
+      -webkit-line-clamp: 2;
+    }
+
+    :host([variant="expanded"]) .preview-title {
+      font-size: 0.9rem;
+      -webkit-line-clamp: 2;
+    }
+
+    .preview-desc {
+      color: #64748b;
+      line-height: 1.4;
+      display: -webkit-box;
+      -webkit-box-orient: vertical;
+      overflow: hidden;
+    }
+
+    :host([variant="compact"]) .preview-desc {
+      font-size: 0.72rem;
+      -webkit-line-clamp: 2;
+    }
+
+    :host([variant="expanded"]) .preview-desc {
+      font-size: 0.8rem;
+      -webkit-line-clamp: 3;
+    }
+
+    .preview-loading {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      color: #94a3b8;
+    }
+
+    :host([variant="compact"]) .preview-loading {
+      padding: 12px 14px;
+      font-size: 0.75rem;
+    }
+
+    :host([variant="expanded"]) .preview-loading {
+      padding: 16px 18px;
+      font-size: 0.8rem;
+    }
+
+    .preview-loading .spinner {
+      border: 2px solid #e2e8f0;
+      border-top-color: #94a3b8;
+      border-radius: 50%;
+      animation: link-preview-spin 0.8s linear infinite;
+    }
+
+    :host([variant="compact"]) .preview-loading .spinner {
+      width: 14px;
+      height: 14px;
+    }
+
+    :host([variant="expanded"]) .preview-loading .spinner {
+      width: 18px;
+      height: 18px;
+    }
+
+    @keyframes link-preview-spin {
+      to { transform: rotate(360deg); }
+    }
+
+    .preview-fallback {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      color: #4f46e5;
+    }
+
+    :host([variant="compact"]) .preview-fallback {
+      padding: 10px 12px;
+      font-size: 0.78rem;
+    }
+
+    :host([variant="expanded"]) .preview-fallback {
+      padding: 14px 16px;
+      font-size: 0.85rem;
+    }
+
+    .preview-fallback img {
+      border-radius: 3px;
+    }
+
+    :host([variant="compact"]) .preview-fallback img {
+      width: 14px;
+      height: 14px;
+    }
+
+    :host([variant="expanded"]) .preview-fallback img {
+      width: 18px;
+      height: 18px;
+    }
+
+    .preview-fallback .link-icon {
+      flex-shrink: 0;
+    }
+
+    :host([variant="compact"]) .preview-fallback .link-icon {
+      width: 16px;
+      height: 16px;
+    }
+
+    :host([variant="expanded"]) .preview-fallback .link-icon {
+      width: 20px;
+      height: 20px;
+    }
+  `;
+
+  @property({ type: String }) url = "";
+  @property({ type: String, reflect: true }) variant: PreviewVariant = "compact";
+  @property({ type: Function }) metadataFetcher: LinkMetadataFetcher | null = null;
+
+  @state() private _metadata: LinkMetadata | null = null;
+  @state() private _loading = false;
+  @state() private _error = false;
+
+  override connectedCallback() {
+    super.connectedCallback();
+    this._fetchMetadata();
+  }
+
+  override updated(changed: Map<string, unknown>) {
+    if (changed.has("url") && changed.get("url") !== undefined) {
+      this._fetchMetadata();
+    }
+  }
+
+  private async _fetchMetadata() {
+    if (!this.url) return;
+
+    if (cache.has(this.url)) {
+      this._metadata = cache.get(this.url)!;
+      return;
+    }
+
+    const fetcher = this.metadataFetcher ?? (window as unknown as Record<string, unknown>).chativaMetadataFetcher as LinkMetadataFetcher | undefined;
+
+    if (!fetcher) {
+      this._error = true;
+      return;
+    }
+
+    this._loading = true;
+    try {
+      const meta = await fetcher(this.url);
+      cache.set(this.url, meta);
+      this._metadata = meta;
+    } catch {
+      this._error = true;
+    } finally {
+      this._loading = false;
+    }
+  }
+
+  private _renderLoading() {
+    return html`
+      <a href=${this.url} target="_blank" rel="noopener noreferrer">
+        <div class="preview-loading">
+          <div class="spinner"></div>
+          <span>${extractDomain(this.url)}</span>
+        </div>
+      </a>
+    `;
+  }
+
+  private _renderFallback() {
+    const domain = extractDomain(this.url);
+    const favicon = getFaviconUrl(this.url);
+    return html`
+      <a href=${this.url} target="_blank" rel="noopener noreferrer">
+        <div class="preview-fallback">
+          <svg class="link-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+            <path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71"/>
+            <path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71"/>
+          </svg>
+          ${favicon ? html`<img src=${favicon} alt="" />` : nothing}
+          <span>${domain}</span>
+        </div>
+      </a>
+    `;
+  }
+
+  private _renderPreview(meta: LinkMetadata) {
+    const domain = meta.domain ?? extractDomain(this.url);
+    const favicon = meta.favicon ?? getFaviconUrl(this.url);
+    return html`
+      <a href=${this.url} target="_blank" rel="noopener noreferrer">
+        ${meta.image
+          ? html`<img class="preview-image" src=${meta.image} alt="" loading="lazy" />`
+          : nothing}
+        <div class="preview-body">
+          <div class="preview-domain">
+            ${favicon ? html`<img src=${favicon} alt="" />` : nothing}
+            <span>${domain}</span>
+          </div>
+          ${meta.title
+            ? html`<div class="preview-title">${meta.title}</div>`
+            : nothing}
+          ${meta.description
+            ? html`<div class="preview-desc">${meta.description}</div>`
+            : nothing}
+        </div>
+      </a>
+    `;
+  }
+
+  render() {
+    if (this._loading) return this._renderLoading();
+    if (this._metadata) return this._renderPreview(this._metadata);
+    if (this._error) return this._renderFallback();
+    return this._renderFallback();
+  }
+}

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -32,10 +32,13 @@ import "./chat-ui/EmojiPicker";
 import "./chat-ui/ConversationList";
 import "./chat-ui/AgentPanel";
 import "./chat-ui/EndOfConversationSurvey";
+import "./chat-ui/LinkPreviewCard";
 
 import { MessageTypeRegistry } from "@chativa/core";
 import { EndOfConversationSurvey } from "./chat-ui/EndOfConversationSurvey";
 export { EndOfConversationSurvey } from "./chat-ui/EndOfConversationSurvey";
+export { LinkPreviewCard } from "./chat-ui/LinkPreviewCard";
+export type { LinkMetadata, LinkMetadataFetcher } from "./chat-ui/LinkPreviewCard";
 MessageTypeRegistry.register(
   "end-of-conversation-survey",
   EndOfConversationSurvey as unknown as typeof HTMLElement,


### PR DESCRIPTION
## Summary

Adds a link preview feature: URLs in incoming text messages are extracted in core and rendered as rich preview cards under the message bubble.

- **core** — new `LinkPreviewExtension` hooking `onAfterReceive`: extracts URLs from text messages (dedupe + trailing-punctuation strip), annotates `data.urls` / `data.previewVariant`. Configurable via `urlExtractor`, `maxUrlsPerMessage`, `defaultVariant`; per-message opt-out with `data.preview = false`, per-message expand with `data.preview = "expanded"`.
- **ui** — new `<link-preview-card>` LitElement with loading / fallback / rich states (favicon, domain, title, description, image), module-level metadata cache, and a pluggable `LinkMetadataFetcher` (element property or `window.chativaMetadataFetcher`). `DefaultTextMessage` renders the cards below the bubble.
- **sandbox** — new **Extensions** tab (install/uninstall toggle, max-URL and variant controls), link-preview demo messages, mock metadata fetcher; `DummyConnector` echoes a link back when the user sends a URL so the preview flow is easy to demo.

## Test plan

- [x] `pnpm --filter @chativa/core test` — 251/251 passing, including 15 new `LinkPreviewExtension` tests (extraction, dedupe, punctuation strip, max-URL cap, opt-out, variants, custom extractor, non-text skip)
- [x] `tsc --noEmit` clean for `packages/ui` and `apps/sandbox`
- [ ] Manual check in sandbox: Extensions tab toggle + the four link-preview demo messages

🤖 Generated with [Claude Code](https://claude.com/claude-code)