### PR TITLE
feat(tool-calls): first-class connector tool-call events with activity UI

### DIFF
--- a/apps/sandbox/src/main.ts
+++ b/apps/sandbox/src/main.ts
@@ -80,5 +80,9 @@ const metadataFetcher = async (url: string): Promise<LinkMetadata> => {
 // Expose metadata fetcher for link preview cards
 (window as unknown as Record<string, unknown>).chativaMetadataFetcher = metadataFetcher;
 
+// Expose tool-call demo trigger for sandbox demo buttons
+(window as unknown as Record<string, unknown>).chativaToolDemo = (scenario: "success" | "error" | "multi" | "genui") =>
+  connector.triggerToolCalls(scenario);
+
 // Dynamic import ensures custom elements are defined after registration
 import("@chativa/ui");

--- a/apps/sandbox/src/sandbox/sections/MessagesSection.ts
+++ b/apps/sandbox/src/sandbox/sections/MessagesSection.ts
@@ -86,6 +86,19 @@ const DEMO_MESSAGES: Array<{ label: string; msg: Record<string, unknown> }> = [
   },
 ];
 
+/** Connector-driven tool-call demos (lifecycle events, not injected messages). */
+const TOOL_DEMOS: Array<{ label: string; scenario: string }> = [
+  { label: "🔧 Tool Calls", scenario: "success" },
+  { label: "🔧 Tool Call Error", scenario: "error" },
+  { label: "🔧 Multi-step Tools", scenario: "multi" },
+  { label: "🔧 Tools → Weather", scenario: "genui" },
+];
+
+function triggerToolDemo(scenario: string): void {
+  const fn = (window as unknown as Record<string, unknown>).chativaToolDemo;
+  if (typeof fn === "function") fn(scenario);
+}
+
 @customElement("sandbox-messages-section")
 export class MessagesSection extends LitElement {
   static override styles = [sectionStyles];
@@ -105,6 +118,9 @@ export class MessagesSection extends LitElement {
           <div class="msg-grid">
             ${DEMO_MESSAGES.map(({ label, msg }) => html`
               <button class="msg-btn" type="button" @click=${() => injectMessage(msg)}>${label}</button>
+            `)}
+            ${TOOL_DEMOS.map(({ label, scenario }) => html`
+              <button class="msg-btn" type="button" @click=${() => triggerToolDemo(scenario)}>${label}</button>
             `)}
           </div>
         </div>

--- a/apps/sandbox/tsconfig.json
+++ b/apps/sandbox/tsconfig.json
@@ -4,6 +4,7 @@
     "paths": {
       "@chativa/core":                ["../../packages/core/src/index.ts"],
       "@chativa/ui":                  ["../../packages/ui/src/index.ts"],
+      "@chativa/genui":               ["../../packages/genui/src/index.ts"],
       "@chativa/connector-dummy":     ["../../packages/connector-dummy/src/index.ts"],
       "@chativa/connector-websocket": ["../../packages/connector-websocket/src/index.ts"],
       "@chativa/connector-signalr":   ["../../packages/connector-signalr/src/index.ts"],

--- a/packages/connector-dummy/src/DummyConnector.ts
+++ b/packages/connector-dummy/src/DummyConnector.ts
@@ -13,6 +13,8 @@ import type {
   AIChunk,
   Conversation,
   ConversationHandler,
+  ToolCall,
+  ToolCallHandler,
 } from "@chativa/core";
 import type { OutgoingMessage } from "@chativa/core";
 
@@ -32,6 +34,7 @@ export class DummyConnector implements IConnector {
   private statusHandler: MessageStatusHandler | null = null;
   private genUIChunkHandler: GenUIChunkHandler | null = null;
   private conversationHandler: ConversationHandler | null = null;
+  private toolCallHandler: ToolCallHandler | null = null;
   private replyDelay: number;
   private connectDelay: number;
 
@@ -122,6 +125,14 @@ export class DummyConnector implements IConnector {
 
     // Trigger demo GenUI streams by command prefix (most-specific first)
     const trimmed = text.trim();
+    if (trimmed.startsWith("/tools-error") && this.toolCallHandler) {
+      this.triggerToolCalls("error");
+      return;
+    }
+    if (trimmed.startsWith("/tools") && this.toolCallHandler) {
+      this.triggerToolCalls("success");
+      return;
+    }
     if (trimmed.startsWith("/genui-weather") && this.genUIChunkHandler) {
       this._streamWeatherDemo(message.id);
       return;
@@ -835,6 +846,153 @@ export class DummyConnector implements IConnector {
     }
   }
 
+  /**
+   * Directly trigger a tool-call demo sequence — used by the sandbox demo
+   * buttons and the `/tools` / `/tools-error` chat commands. Emits lifecycle
+   * events (running → completed/error) followed by a final bot reply.
+   * The "genui" scenario finishes with a GenUI weather widget stream instead
+   * of a text message, demonstrating traces on custom components.
+   */
+  triggerToolCalls(scenario: "success" | "error" | "multi" | "genui" = "success"): void {
+    const emit = (tc: ToolCall) => this.toolCallHandler?.(tc);
+    const runId = `tool-${Date.now()}-${Math.random().toString(36).slice(2, 6)}`;
+
+    interface DemoStep {
+      name: string;
+      description: string;
+      params: Record<string, unknown>;
+      /** How long the tool "runs" before settling. */
+      duration: number;
+      result?: unknown;
+      error?: string;
+    }
+
+    const steps: DemoStep[] =
+      scenario === "error"
+        ? [
+            {
+              name: "get_weather",
+              description: "Fetching current weather",
+              params: { city: "San Francisco" },
+              duration: 900,
+              error: "fetch failed",
+            },
+          ]
+        : scenario === "genui"
+          ? [
+              {
+                name: "get_weather",
+                description: "Fetching current weather",
+                params: { city: "San Francisco", days: 3 },
+                duration: 1000,
+                result: { tempC: 18, condition: "partly cloudy" },
+              },
+            ]
+        : scenario === "multi"
+          ? [
+              {
+                name: "lookup_customer",
+                description: "Looking up customer account",
+                params: { email: "jane@example.com" },
+                duration: 700,
+                result: { customerId: "cus_481", name: "Jane Doe" },
+              },
+              {
+                name: "list_orders",
+                description: "Listing recent orders",
+                params: { customerId: "cus_481", limit: 5 },
+                duration: 800,
+                result: { orders: [{ id: "ord_1042", total: 79.9 }, { id: "ord_1017", total: 24.5 }] },
+              },
+              {
+                name: "get_shipment_status",
+                description: "Checking shipment status",
+                params: { orderId: "ord_1042" },
+                duration: 1200,
+                result: { status: "in_transit", carrier: "DHL", eta: "2 days" },
+              },
+            ]
+          : [
+              {
+                name: "get_weather",
+                description: "Fetching current weather",
+                params: { city: "San Francisco" },
+                duration: 900,
+                result: { tempC: 18, condition: "partly cloudy" },
+              },
+              {
+                name: "get_forecast",
+                description: "Fetching 3-day forecast",
+                params: { city: "San Francisco", days: 3 },
+                duration: 1100,
+                result: [
+                  { day: "Tue", tempC: 19 },
+                  { day: "Wed", tempC: 17 },
+                  { day: "Thu", tempC: 21 },
+                ],
+              },
+            ];
+
+    this.typingHandler?.(true);
+
+    let at = 300;
+    steps.forEach((step, i) => {
+      const id = `${runId}-${i}`;
+      const startAt = at;
+      setTimeout(() => {
+        emit({
+          id,
+          name: step.name,
+          description: step.description,
+          status: "running",
+          params: step.params,
+          startedAt: Date.now(),
+        });
+      }, startAt);
+
+      at += step.duration;
+      const endAt = at;
+      setTimeout(() => {
+        emit({
+          id,
+          name: step.name,
+          description: step.description,
+          status: step.error ? "error" : "completed",
+          params: step.params,
+          result: step.result,
+          error: step.error,
+          endedAt: Date.now(),
+        });
+      }, endAt);
+
+      at += 150; // small gap before the next tool starts
+    });
+
+    setTimeout(() => {
+      this.typingHandler?.(false);
+
+      // GenUI finale: the reply is a streamed weather widget, not text
+      if (scenario === "genui") {
+        this._streamWeatherDemo(`${runId}-genui`);
+        return;
+      }
+
+      const failed = steps.some((s) => s.error);
+      this.messageHandler?.({
+        id: `dummy-tools-${Date.now()}`,
+        type: "text",
+        data: {
+          text: failed
+            ? "I tried to fetch the weather but the service is unreachable right now. Please try again later."
+            : scenario === "multi"
+              ? "Your latest order **#ord_1042** ($79.90) is **in transit** with DHL — estimated delivery in **2 days**."
+              : "It's **18°C** and partly cloudy in San Francisco. The next days look similar: 19° / 17° / 21°.",
+        },
+        timestamp: Date.now(),
+      });
+    }, at + 300);
+  }
+
   receiveComponentEvent(streamId: string, eventType: string, _payload: unknown): void {
     if (eventType === "form_submit") {
       // Simulate server processing then respond with success
@@ -872,6 +1030,10 @@ export class DummyConnector implements IConnector {
 
   onGenUIChunk(callback: GenUIChunkHandler): void {
     this.genUIChunkHandler = callback;
+  }
+
+  onToolCall(callback: ToolCallHandler): void {
+    this.toolCallHandler = callback;
   }
 
   async sendFeedback(messageId: string, feedback: FeedbackType): Promise<void> {

--- a/packages/connector-dummy/src/__tests__/DummyConnector.test.ts
+++ b/packages/connector-dummy/src/__tests__/DummyConnector.test.ts
@@ -124,6 +124,94 @@ describe("DummyConnector", () => {
     expect(named.name).toBe("my-connector");
   });
 
+  // ── Tool calls ────────────────────────────────────────────────────
+
+  describe("tool calls", () => {
+    it("triggerToolCalls('success') emits running→completed per tool, then a reply", () => {
+      vi.useFakeTimers();
+      try {
+        const toolHandler = vi.fn();
+        const messageHandler = vi.fn();
+        connector.onToolCall(toolHandler);
+        connector.onMessage(messageHandler);
+
+        connector.triggerToolCalls("success");
+        vi.runAllTimers();
+
+        // 2 demo tools × (running + completed)
+        expect(toolHandler).toHaveBeenCalledTimes(4);
+        const events = toolHandler.mock.calls.map((c) => c[0]);
+        expect(events[0]).toMatchObject({ name: "get_weather", status: "running" });
+        expect(events[1]).toMatchObject({ name: "get_weather", status: "completed" });
+        expect(events[1].result).toBeDefined();
+        expect(events[3]).toMatchObject({ name: "get_forecast", status: "completed" });
+        // running/completed pairs share the same id
+        expect(events[0].id).toBe(events[1].id);
+
+        expect(messageHandler).toHaveBeenCalledOnce();
+        expect(messageHandler.mock.calls[0][0].type).toBe("text");
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it("triggerToolCalls('error') settles the tool with status error", () => {
+      vi.useFakeTimers();
+      try {
+        const toolHandler = vi.fn();
+        const messageHandler = vi.fn();
+        connector.onToolCall(toolHandler);
+        connector.onMessage(messageHandler);
+
+        connector.triggerToolCalls("error");
+        vi.runAllTimers();
+
+        const events = toolHandler.mock.calls.map((c) => c[0]);
+        expect(events.at(-1)).toMatchObject({ status: "error", error: "fetch failed" });
+        expect(messageHandler).toHaveBeenCalledOnce();
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it("'/tools' chat command triggers the demo instead of an echo", async () => {
+      await connector.connect();
+      vi.useFakeTimers();
+      try {
+        const toolHandler = vi.fn();
+        connector.onToolCall(toolHandler);
+        connector.onMessage(vi.fn());
+
+        await connector.sendMessage({ id: "1", type: "text", data: { text: "/tools" }, timestamp: Date.now() });
+        vi.runAllTimers();
+        expect(toolHandler).toHaveBeenCalled();
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it("triggerToolCalls('genui') finishes with a GenUI stream instead of text", () => {
+      vi.useFakeTimers();
+      try {
+        const toolHandler = vi.fn();
+        const messageHandler = vi.fn();
+        const genUIHandler = vi.fn();
+        connector.onToolCall(toolHandler);
+        connector.onMessage(messageHandler);
+        connector.onGenUIChunk(genUIHandler);
+
+        connector.triggerToolCalls("genui");
+        vi.runAllTimers();
+
+        expect(toolHandler).toHaveBeenCalledTimes(2); // running + completed
+        expect(messageHandler).not.toHaveBeenCalled();
+        expect(genUIHandler).toHaveBeenCalled();
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+  });
+
   // ── Multi-conversation ────────────────────────────────────────────
 
   describe("multi-conversation", () => {

--- a/packages/connector-websocket/src/WebSocketConnector.ts
+++ b/packages/connector-websocket/src/WebSocketConnector.ts
@@ -4,6 +4,8 @@ import type {
   ConnectHandler,
   DisconnectHandler,
   SurveyPayload,
+  ToolCall,
+  ToolCallHandler,
 } from "@chativa/core";
 import type { OutgoingMessage } from "@chativa/core";
 
@@ -28,6 +30,7 @@ export class WebSocketConnector implements IConnector {
   private messageHandler: MessageHandler | null = null;
   private connectHandler: ConnectHandler | null = null;
   private disconnectHandler: DisconnectHandler | null = null;
+  private toolCallHandler: ToolCallHandler | null = null;
 
   private reconnectAttempts = 0;
 
@@ -58,6 +61,15 @@ export class WebSocketConnector implements IConnector {
       this.ws.onmessage = (event: MessageEvent) => {
         try {
           const data = JSON.parse(event.data as string);
+          // Tool-call lifecycle frame: { type: "tool_call", data: {...ToolCall} }
+          // (the payload may also be flattened onto the frame itself).
+          if (data?.type === "tool_call") {
+            const payload = (data.data ?? data) as ToolCall;
+            if (payload.id && payload.name && payload.status) {
+              this.toolCallHandler?.(payload);
+            }
+            return;
+          }
           this.messageHandler?.(data);
         } catch {
           this.messageHandler?.({
@@ -112,5 +124,9 @@ export class WebSocketConnector implements IConnector {
 
   onDisconnect(callback: DisconnectHandler): void {
     this.disconnectHandler = callback;
+  }
+
+  onToolCall(callback: ToolCallHandler): void {
+    this.toolCallHandler = callback;
   }
 }

--- a/packages/core/src/application/ChatEngine.ts
+++ b/packages/core/src/application/ChatEngine.ts
@@ -34,8 +34,22 @@ export class ChatEngine {
     this.connector.onMessage((msg) => {
       chatStore.getState().setTyping(false);
 
-      const transformed = ExtensionRegistry.runAfterReceive(msg);
+      let transformed = ExtensionRegistry.runAfterReceive(msg);
       if (transformed === null) return; // extension blocked it
+
+      // Attach the tool-call trace collected for this reply, then reset the
+      // buffer so the next turn starts clean. A connector that already put
+      // `toolCalls` in the message data wins over the collected buffer.
+      const toolCalls = chatStore.getState().activeToolCalls;
+      if (toolCalls.length > 0) {
+        if (transformed.data?.toolCalls === undefined) {
+          transformed = {
+            ...transformed,
+            data: { ...transformed.data, toolCalls: [...toolCalls] },
+          };
+        }
+        chatStore.getState().clearToolCalls();
+      }
 
       // Increment unread count when chat is closed
       if (!chatStore.getState().isOpened) {
@@ -65,6 +79,12 @@ export class ChatEngine {
 
     this.connector.onGenUIChunk?.((streamId, chunk, done) => {
       this._handleGenUIChunk(streamId, chunk, done);
+    });
+
+    // Tool-call lifecycle events accumulate in the store until the reply
+    // arrives; upsertToolCall also emits "tool_call_updated" on the EventBus.
+    this.connector.onToolCall?.((toolCall) => {
+      chatStore.getState().upsertToolCall(toolCall);
     });
 
     // Inject Chativa context so connector event handlers can interact with the UI
@@ -193,11 +213,19 @@ export class ChatEngine {
       this._genUIStreams.set(streamId, msgId);
       this._msgToStream.set(msgId, streamId);
       const data: GenUIStreamState = { chunks: [chunk], streamingComplete: done };
+      const record = data as unknown as Record<string, unknown>;
+      // A GenUI reply can follow tool calls just like a text reply — attach
+      // the collected trace to the stream's message and reset the buffer.
+      const toolCalls = chatStore.getState().activeToolCalls;
+      if (toolCalls.length > 0) {
+        record.toolCalls = [...toolCalls];
+        chatStore.getState().clearToolCalls();
+      }
       messageStore.getState().addMessage({
         id: msgId,
         type: "genui",
         from: "bot",
-        data: data as unknown as Record<string, unknown>,
+        data: record,
         timestamp: Date.now(),
         component: Component,
       });
@@ -219,8 +247,10 @@ export class ChatEngine {
       if (chunk.type === "event") {
         updated.chunks = [...prevState.chunks, chunk];
       }
+      // Spread the previous data first so extra fields attached at creation
+      // time (e.g. toolCalls) survive chunk updates.
       messageStore.getState().updateById(msgId, {
-        data: updated as unknown as Record<string, unknown>,
+        data: { ...current?.data, ...(updated as unknown as Record<string, unknown>) },
       });
     }
 

--- a/packages/core/src/application/EventBus.ts
+++ b/packages/core/src/application/EventBus.ts
@@ -15,6 +15,7 @@
  * ```
  */
 import type { OutgoingMessage, IncomingMessage } from "../domain/entities/Message";
+import type { ToolCall } from "../domain/entities/ToolCall";
 import type { ConnectorStatus } from "./stores/ChatStore";
 import type { SurveyPayload } from "../domain/ports/IConnector";
 
@@ -43,6 +44,8 @@ export interface EventBusPayloadMap {
   search_query_changed: { query: string };
   /** User submitted an end-of-conversation survey. */
   survey_submitted: SurveyPayload;
+  /** A connector tool call started or changed state (upsert by `id`). */
+  tool_call_updated: ToolCall;
 }
 
 export type EventBusEventName = keyof EventBusPayloadMap;

--- a/packages/core/src/application/__tests__/ChatEngine.test.ts
+++ b/packages/core/src/application/__tests__/ChatEngine.test.ts
@@ -13,21 +13,25 @@ import type {
   MessageStatusHandler,
 } from "../../domain/ports/IConnector";
 import type { AIChunk, GenUIChunkHandler } from "../../domain/entities/GenUI";
+import type { ToolCall, ToolCallHandler } from "../../domain/entities/ToolCall";
 import { DEFAULT_THEME } from "../../domain/value-objects/Theme";
 
 /** Create a controllable mock connector. */
 function createMockConnector(): IConnector & {
   simulateIncoming: (text: string, id?: string) => void;
+  simulateIncomingRaw: (msg: Parameters<MessageHandler>[0]) => void;
   simulateDisconnect: (reason?: string) => void;
   simulateTyping: (v: boolean) => void;
   simulateMessageStatus: (msgId: string, status: "sending" | "sent" | "read") => void;
   simulateGenUIChunk: (streamId: string, chunk: AIChunk, done: boolean) => void;
+  simulateToolCall: (toolCall: ToolCall) => void;
 } {
   let msgHandler: MessageHandler | null = null;
   let disconnectHandler: DisconnectHandler | null = null;
   let typingHandler: TypingHandler | null = null;
   let statusHandler: MessageStatusHandler | null = null;
   let genUIHandler: GenUIChunkHandler | null = null;
+  let toolCallHandler: ToolCallHandler | null = null;
 
   return {
     name: "mock",
@@ -44,13 +48,16 @@ function createMockConnector(): IConnector & {
     onTyping(cb) { typingHandler = cb; },
     onMessageStatus(cb) { statusHandler = cb; },
     onGenUIChunk(cb) { genUIHandler = cb; },
+    onToolCall(cb) { toolCallHandler = cb; },
     simulateIncoming(text: string, id = `sim-${Date.now()}`) {
       msgHandler?.({ id, type: "text", data: { text }, timestamp: Date.now() });
     },
+    simulateIncomingRaw(msg) { msgHandler?.(msg); },
     simulateDisconnect(reason?: string) { disconnectHandler?.(reason); },
     simulateTyping(v: boolean) { typingHandler?.(v); },
     simulateMessageStatus(msgId: string, status: "sending" | "sent" | "read") { statusHandler?.(msgId, status); },
     simulateGenUIChunk(streamId, chunk, done) { genUIHandler?.(streamId, chunk, done); },
+    simulateToolCall(toolCall) { toolCallHandler?.(toolCall); },
   };
 }
 
@@ -78,6 +85,7 @@ describe("ChatEngine", () => {
       isLoadingHistory: false,
       historyCursor: undefined,
       searchQuery: "",
+      activeToolCalls: [],
     });
   });
 
@@ -620,5 +628,87 @@ describe("ChatEngine", () => {
     await engine.init();
     engine.receiveComponentEvent("unknown-id", "click", {});
     expect(connector.receiveComponentEvent).not.toHaveBeenCalled();
+  });
+
+  // ── tool calls ─────────────────────────────────────────────────────
+
+  it("collects connector tool-call events into chatStore.activeToolCalls", async () => {
+    const connector = createMockConnector();
+    const engine = new ChatEngine(connector);
+    await engine.init();
+
+    connector.simulateToolCall({ id: "t1", name: "get_weather", status: "running", params: { city: "SF" } });
+    expect(chatStore.getState().activeToolCalls).toHaveLength(1);
+    expect(chatStore.getState().activeToolCalls[0].status).toBe("running");
+
+    connector.simulateToolCall({ id: "t1", name: "get_weather", status: "completed", result: { tempC: 18 } });
+    const calls = chatStore.getState().activeToolCalls;
+    expect(calls).toHaveLength(1);
+    expect(calls[0].status).toBe("completed");
+    expect(calls[0].params).toEqual({ city: "SF" });
+  });
+
+  it("attaches the collected trace to the next bot message and clears the buffer", async () => {
+    const connector = createMockConnector();
+    const engine = new ChatEngine(connector);
+    await engine.init();
+
+    connector.simulateToolCall({ id: "t1", name: "get_weather", status: "completed" });
+    connector.simulateToolCall({ id: "t2", name: "get_forecast", status: "error", error: "fetch failed" });
+    connector.simulateIncoming("Here is the weather", "reply-1");
+
+    const msg = messageStore.getState().messages.find((m) => m.id === "reply-1");
+    const toolCalls = msg?.data?.toolCalls as Array<{ id: string; status: string }>;
+    expect(toolCalls).toHaveLength(2);
+    expect(toolCalls.map((tc) => tc.id)).toEqual(["t1", "t2"]);
+    expect(chatStore.getState().activeToolCalls).toEqual([]);
+  });
+
+  it("does not attach toolCalls when no tool events were collected", async () => {
+    const connector = createMockConnector();
+    const engine = new ChatEngine(connector);
+    await engine.init();
+
+    connector.simulateIncoming("plain reply", "reply-plain");
+    const msg = messageStore.getState().messages.find((m) => m.id === "reply-plain");
+    expect(msg?.data?.toolCalls).toBeUndefined();
+  });
+
+  it("keeps connector-supplied data.toolCalls but still clears the buffer", async () => {
+    const connector = createMockConnector();
+    const engine = new ChatEngine(connector);
+    await engine.init();
+
+    connector.simulateToolCall({ id: "buffered", name: "a", status: "completed" });
+    connector.simulateIncomingRaw({
+      id: "reply-own",
+      type: "text",
+      data: { text: "hi", toolCalls: [{ id: "own", name: "b", status: "completed" }] },
+      timestamp: Date.now(),
+    });
+
+    const msg = messageStore.getState().messages.find((m) => m.id === "reply-own");
+    const toolCalls = msg?.data?.toolCalls as Array<{ id: string }>;
+    expect(toolCalls.map((tc) => tc.id)).toEqual(["own"]);
+    expect(chatStore.getState().activeToolCalls).toEqual([]);
+  });
+
+  it("attaches the trace to a GenUI stream message and keeps it across chunks", async () => {
+    const connector = createMockConnector();
+    const engine = new ChatEngine(connector);
+    await engine.init();
+
+    connector.simulateToolCall({ id: "t1", name: "get_weather", status: "completed" });
+    connector.simulateGenUIChunk("s-tools", { type: "text", content: "Weather:", id: 1 }, false);
+
+    let data = messageStore.getState().messages[0].data as Record<string, unknown>;
+    expect((data.toolCalls as unknown[])).toHaveLength(1);
+    expect(chatStore.getState().activeToolCalls).toEqual([]);
+
+    // Subsequent chunks must not wipe the attached trace
+    connector.simulateGenUIChunk("s-tools", { type: "ui", component: "weather", props: {}, id: 2 }, true);
+    data = messageStore.getState().messages[0].data as Record<string, unknown>;
+    expect((data.toolCalls as unknown[])).toHaveLength(1);
+    expect((data.chunks as unknown[])).toHaveLength(2);
   });
 });

--- a/packages/core/src/application/stores/ChatStore.ts
+++ b/packages/core/src/application/stores/ChatStore.ts
@@ -5,6 +5,7 @@ import {
     type ThemeConfig,
 } from "../../domain/value-objects/Theme";
 import type { DeepPartial } from "../../domain/value-objects/Theme";
+import type { ToolCall } from "../../domain/entities/ToolCall";
 import { EventBus } from "../EventBus";
 
 // Re-export for backwards compatibility
@@ -56,6 +57,12 @@ export interface ChatStoreState {
     historyCursor?: string;
     /** Current search query; empty string means no active search. */
     searchQuery: string;
+    /**
+     * Tool calls collected for the reply currently being produced.
+     * Upserted by ChatEngine as the connector reports progress; cleared when
+     * the next bot message arrives (the snapshot moves onto that message).
+     */
+    activeToolCalls: ToolCall[];
 
     toggle: () => void;
     open: () => void;
@@ -77,6 +84,10 @@ export interface ChatStoreState {
     setHistoryCursor: (cursor: string | undefined) => void;
     setSearchQuery: (q: string) => void;
     clearSearch: () => void;
+    /** Insert or merge a tool call by `id` (later events win field-by-field). */
+    upsertToolCall: (toolCall: ToolCall) => void;
+    /** Drop all collected tool calls (e.g. after attaching them to a message). */
+    clearToolCalls: () => void;
     /**
      * Reset all per-session runtime fields (history pagination, typing,
      * unread, reconnect attempts) back to their initial values. Preserves
@@ -109,6 +120,7 @@ const store = createStore<ChatStoreState>((setState, getState) => ({
     historyCursor: undefined,
     showMessageStatus: true,
     searchQuery: "",
+    activeToolCalls: [],
 
     toggle: () => {
         setState((s) => ({
@@ -197,6 +209,21 @@ const store = createStore<ChatStoreState>((setState, getState) => ({
         EventBus.emit("search_query_changed", { query: "" });
     },
 
+    upsertToolCall: (toolCall: ToolCall) => {
+        setState((s) => {
+            const idx = s.activeToolCalls.findIndex((tc) => tc.id === toolCall.id);
+            if (idx === -1) {
+                return { activeToolCalls: [...s.activeToolCalls, toolCall] };
+            }
+            const merged = [...s.activeToolCalls];
+            merged[idx] = { ...merged[idx], ...toolCall };
+            return { activeToolCalls: merged };
+        });
+        EventBus.emit("tool_call_updated", toolCall);
+    },
+
+    clearToolCalls: () => setState(() => ({ activeToolCalls: [] })),
+
     resetSession: () => {
         if (_typingTimer !== null) {
             clearTimeout(_typingTimer);
@@ -211,6 +238,7 @@ const store = createStore<ChatStoreState>((setState, getState) => ({
             isLoadingHistory: false,
             historyCursor: undefined,
             searchQuery: "",
+            activeToolCalls: [],
         }));
         if (hadSearch) {
             EventBus.emit("search_query_changed", { query: "" });

--- a/packages/core/src/application/stores/__tests__/ChatStore.test.ts
+++ b/packages/core/src/application/stores/__tests__/ChatStore.test.ts
@@ -14,6 +14,7 @@ describe("ChatStore", () => {
       activeConnector: "dummy",
       connectorStatus: "idle",
       theme: DEFAULT_THEME,
+      activeToolCalls: [],
     });
   });
 
@@ -360,6 +361,64 @@ describe("ChatStore", () => {
     chatStore.getState().close();
     expect(handler).toHaveBeenCalledOnce();
     EventBus.off("widget_closed", handler);
+  });
+
+  // ── tool calls ─────────────────────────────────────────────────────
+
+  it("upsertToolCall() appends a new tool call", () => {
+    chatStore.getState().upsertToolCall({ id: "t1", name: "get_weather", status: "running" });
+    expect(chatStore.getState().activeToolCalls).toEqual([
+      { id: "t1", name: "get_weather", status: "running" },
+    ]);
+  });
+
+  it("upsertToolCall() merges updates into an existing call by id", () => {
+    chatStore.getState().upsertToolCall({
+      id: "t1",
+      name: "get_weather",
+      status: "running",
+      params: { city: "SF" },
+    });
+    chatStore.getState().upsertToolCall({
+      id: "t1",
+      name: "get_weather",
+      status: "completed",
+      result: { tempC: 18 },
+    });
+
+    const calls = chatStore.getState().activeToolCalls;
+    expect(calls).toHaveLength(1);
+    expect(calls[0].status).toBe("completed");
+    expect(calls[0].result).toEqual({ tempC: 18 });
+    // Fields from the earlier event survive the merge
+    expect(calls[0].params).toEqual({ city: "SF" });
+  });
+
+  it("upsertToolCall() keeps insertion order for distinct ids", () => {
+    chatStore.getState().upsertToolCall({ id: "t1", name: "a", status: "running" });
+    chatStore.getState().upsertToolCall({ id: "t2", name: "b", status: "running" });
+    chatStore.getState().upsertToolCall({ id: "t1", name: "a", status: "completed" });
+    expect(chatStore.getState().activeToolCalls.map((tc) => tc.id)).toEqual(["t1", "t2"]);
+  });
+
+  it("upsertToolCall() emits tool_call_updated on the EventBus", () => {
+    const handler = vi.fn();
+    EventBus.on("tool_call_updated", handler);
+    chatStore.getState().upsertToolCall({ id: "t1", name: "get_weather", status: "running" });
+    expect(handler).toHaveBeenCalledWith({ id: "t1", name: "get_weather", status: "running" });
+    EventBus.off("tool_call_updated", handler);
+  });
+
+  it("clearToolCalls() empties the buffer", () => {
+    chatStore.getState().upsertToolCall({ id: "t1", name: "a", status: "running" });
+    chatStore.getState().clearToolCalls();
+    expect(chatStore.getState().activeToolCalls).toEqual([]);
+  });
+
+  it("resetSession() clears activeToolCalls", () => {
+    chatStore.getState().upsertToolCall({ id: "t1", name: "a", status: "running" });
+    chatStore.getState().resetSession();
+    expect(chatStore.getState().activeToolCalls).toEqual([]);
   });
 
   // ── subscribe ──────────────────────────────────────────────────────

--- a/packages/core/src/domain/entities/ToolCall.ts
+++ b/packages/core/src/domain/entities/ToolCall.ts
@@ -1,0 +1,36 @@
+/**
+ * Domain entities for connector tool calls (agent/LLM tool use).
+ * No external dependencies allowed in this file.
+ */
+
+/** Lifecycle state of a single tool invocation. */
+export type ToolCallStatus = "running" | "completed" | "error";
+
+/**
+ * A single tool invocation reported by a connector.
+ *
+ * Connectors emit the same `id` multiple times as the call progresses
+ * (running → completed/error); consumers upsert by `id`.
+ */
+export interface ToolCall {
+  /** Unique id for this invocation (e.g. an Anthropic `tool_use` id). */
+  id: string;
+  /** Tool name, e.g. "get_weather". */
+  name: string;
+  /** Human-readable description of what the tool is doing, shown in the activity line. */
+  description?: string;
+  status: ToolCallStatus;
+  /** Input parameters the tool was invoked with. */
+  params?: Record<string, unknown>;
+  /** Result payload — present once `status` is "completed". */
+  result?: unknown;
+  /** Error message — present once `status` is "error". */
+  error?: string;
+  /** Epoch ms when the call started. */
+  startedAt?: number;
+  /** Epoch ms when the call settled (completed or error). */
+  endedAt?: number;
+}
+
+/** Callback registered via IConnector.onToolCall(). */
+export type ToolCallHandler = (toolCall: ToolCall) => void;

--- a/packages/core/src/domain/index.ts
+++ b/packages/core/src/domain/index.ts
@@ -1,6 +1,7 @@
 // Domain — pure types and interfaces
 export type { IncomingMessage, OutgoingMessage, MessageSender, MessageAction, MessageStatus, HistoryResult } from "./entities/Message";
 export type { AIChunk, AIChunkText, AIChunkUI, AIChunkEvent, GenUIStreamState, GenUIChunkHandler } from "./entities/GenUI";
+export type { ToolCall, ToolCallStatus, ToolCallHandler } from "./entities/ToolCall";
 export { createOutgoingMessage } from "./entities/Message";
 export type { Conversation, ConversationStatus } from "./entities/Conversation";
 export type {

--- a/packages/core/src/domain/ports/IConnector.ts
+++ b/packages/core/src/domain/ports/IConnector.ts
@@ -9,6 +9,7 @@
 
 import type { IncomingMessage, OutgoingMessage, HistoryResult, MessageStatus } from "../entities/Message";
 import type { GenUIChunkHandler } from "../entities/GenUI";
+import type { ToolCallHandler } from "../entities/ToolCall";
 import type { Conversation } from "../entities/Conversation";
 import type { ChativaContext } from "../../application/ChativaContext";
 
@@ -92,6 +93,14 @@ export interface IConnector {
 
   /** Optional: register a callback for Generative UI streaming chunks. */
   onGenUIChunk?(callback: GenUIChunkHandler): void;
+
+  /**
+   * Optional: register a callback for tool-call lifecycle events.
+   * Connectors report each invocation as it progresses by emitting the same
+   * ToolCall `id` with updated fields (running → completed/error).
+   * ChatEngine collects them and attaches the trace to the next bot message.
+   */
+  onToolCall?(callback: ToolCallHandler): void;
 
   /**
    * Optional: called by ChatEngine when a GenUI component fires `sendEvent`.

--- a/packages/ui/src/chat-ui/ChatMessageList.ts
+++ b/packages/ui/src/chat-ui/ChatMessageList.ts
@@ -5,7 +5,8 @@ import { html as staticHtml } from "lit/static-html.js";
 import { t } from "i18next";
 import i18next from "../i18n/i18n";
 
-import { messageStore, chatStore, type StoredMessage } from "@chativa/core";
+import { messageStore, chatStore, type StoredMessage, type ToolCall } from "@chativa/core";
+import "./ToolCallActivity";
 
 function resolveTag(component: typeof HTMLElement): string {
   const name = customElements.getName?.(component);
@@ -170,6 +171,25 @@ class ChatMessageList extends LitElement {
       margin: 0;
     }
 
+    /* Live tool-call activity strip (bot is working) */
+    .tool-activity-live {
+      margin-top: 4px;
+      width: fit-content;
+      max-width: 85%;
+    }
+
+    /* Trace attached above a delivered bot message */
+    .tool-activity-attached {
+      margin: 6px 0 2px;
+      width: fit-content;
+      max-width: 85%;
+    }
+
+    /* Align with the bubble, past the 28px avatar + 8px gap */
+    .tool-activity-attached.avatar-offset {
+      margin-left: 36px;
+    }
+
     /* Typing indicator */
     .typing-bubble {
       display: flex;
@@ -304,6 +324,7 @@ class ChatMessageList extends LitElement {
   private _prevMessageCount = 0;
   private _prevVersion = 0;
   private _prevIsTyping = false;
+  private _prevToolCallCount = 0;
   /** Set to true while a history load is in-flight; cleared in updated(). */
   private _prevIsLoadingHistory = false;
   /** scrollHeight captured just before history load starts. */
@@ -351,10 +372,14 @@ class ChatMessageList extends LitElement {
   updated() {
     const { messages, version } = messageStore.getState();
     const currentCount = messages.length;
-    const { isTyping, isLoadingHistory } = chatStore.getState();
+    const { isTyping, isLoadingHistory, activeToolCalls } = chatStore.getState();
 
     const typingChanged = isTyping !== this._prevIsTyping;
     this._prevIsTyping = isTyping;
+
+    // The live tool-activity strip appearing/growing changes list height
+    const toolCallsChanged = activeToolCalls.length !== this._prevToolCallCount;
+    this._prevToolCallCount = activeToolCalls.length;
 
     // Detect when history loading just finished (true → false transition)
     const historyJustLoaded = this._prevIsLoadingHistory && !isLoadingHistory;
@@ -406,7 +431,7 @@ class ChatMessageList extends LitElement {
       // GenUI update while user is scrolled up — show pill
       this._hasNewMessages = true;
       this.requestUpdate();
-    } else if (typingChanged && this._isAtBottom) {
+    } else if ((typingChanged || toolCallsChanged) && this._isAtBottom) {
       this._pinToBottom();
     }
   }
@@ -448,7 +473,7 @@ class ChatMessageList extends LitElement {
       : "default-text-message";
     const next = messages[i + 1];
     const isLastInGroup = !next || next.from !== msg.from;
-    return staticHtml`<${unsafeStatic(tag)}
+    const rendered = staticHtml`<${unsafeStatic(tag)}
       .messageData=${msg.data}
       .sender=${msg.from ?? "bot"}
       .messageId=${msg.id}
@@ -456,11 +481,26 @@ class ChatMessageList extends LitElement {
       .hideAvatar=${!isLastInGroup}
       .status=${msg.status ?? "sent"}
     ></${unsafeStatic(tag)}>`;
+
+    // Tool-call trace attaches at list level so every message type — built-in
+    // or custom (e.g. a GenUI weather widget) — gets the activity line above it.
+    const toolCalls = msg.from !== "user"
+      ? (msg.data?.toolCalls as ToolCall[] | undefined)
+      : undefined;
+    if (!toolCalls || toolCalls.length === 0) return rendered;
+
+    const showBotAvatar = chatStore.getState().theme.avatar?.showBot !== false;
+    return html`
+      <div class="tool-activity-attached ${showBotAvatar ? "avatar-offset" : ""}">
+        <tool-call-activity .toolCalls=${toolCalls}></tool-call-activity>
+      </div>
+      ${rendered}
+    `;
   }
 
   render() {
     const messages = messageStore.getState().messages;
-    const { connectorStatus, isTyping, reconnectAttempt, hasMoreHistory, isLoadingHistory, searchQuery } = chatStore.getState();
+    const { connectorStatus, isTyping, reconnectAttempt, hasMoreHistory, isLoadingHistory, searchQuery, activeToolCalls } = chatStore.getState();
 
     const displayMessages = searchQuery
       ? messages.filter((msg) => {
@@ -552,6 +592,12 @@ class ChatMessageList extends LitElement {
               </div>
             `
           : displayMessages.map((msg, i) => this._renderMessage(msg, i, displayMessages))}
+
+        ${activeToolCalls.length > 0 ? html`
+          <div class="tool-activity-live" role="status">
+            <tool-call-activity live .toolCalls=${activeToolCalls}></tool-call-activity>
+          </div>
+        ` : null}
 
         ${isTyping ? html`
           <div

--- a/packages/ui/src/chat-ui/ChatWidget.ts
+++ b/packages/ui/src/chat-ui/ChatWidget.ts
@@ -615,6 +615,7 @@ export class ChatWidget extends ChatbotMixin(LitElement) {
         isLoadingHistory: false,
         historyCursor: undefined,
         searchQuery: "",
+        activeToolCalls: [],
         isFullscreen: false,
         isRendered: false,
       });

--- a/packages/ui/src/chat-ui/ToolCallActivity.ts
+++ b/packages/ui/src/chat-ui/ToolCallActivity.ts
@@ -1,0 +1,165 @@
+import { LitElement, html, css, nothing } from "lit";
+import { customElement, property, state } from "lit/decorators.js";
+import { t } from "i18next";
+import "../i18n/i18n";
+import type { ToolCall } from "@chativa/core";
+import "./ToolCallCard";
+
+/**
+ * <tool-call-activity> — one-line tool activity strip, expandable to the
+ * full invocation trace.
+ *
+ * Two modes:
+ * - `live` — rendered by the message list while the bot is still working.
+ *   The line shows the currently running tool's description (or name) with
+ *   a spinner.
+ * - attached (default) — rendered right above a bot message that carries a
+ *   `data.toolCalls` trace. The line shows a compact summary
+ *   ("N operations · M failed").
+ *
+ * Clicking the line toggles the full list of <tool-call-card>s.
+ */
+@customElement("tool-call-activity")
+export class ToolCallActivity extends LitElement {
+  static override styles = css`
+    :host {
+      display: block;
+      max-width: 340px;
+    }
+
+    .line {
+      display: flex;
+      align-items: center;
+      gap: 7px;
+      width: 100%;
+      padding: 5px 10px;
+      border: 1px solid #e2e8f0;
+      border-radius: 999px;
+      background: #f8fafc;
+      cursor: pointer;
+      font-family: inherit;
+      font-size: 0.72rem;
+      color: #475569;
+      text-align: left;
+    }
+
+    .line:hover {
+      background: #f1f5f9;
+    }
+
+    .line-icon {
+      width: 13px;
+      height: 13px;
+      flex-shrink: 0;
+      color: #64748b;
+    }
+
+    .label {
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+      min-width: 0;
+    }
+
+    .count-error {
+      color: #b91c1c;
+      font-weight: 600;
+      flex-shrink: 0;
+    }
+
+    .spinner {
+      width: 11px;
+      height: 11px;
+      flex-shrink: 0;
+      border: 2px solid #e2e8f0;
+      border-top-color: #4f46e5;
+      border-radius: 50%;
+      animation: tool-activity-spin 0.8s linear infinite;
+    }
+
+    @keyframes tool-activity-spin {
+      to { transform: rotate(360deg); }
+    }
+
+    .chevron {
+      width: 13px;
+      height: 13px;
+      flex-shrink: 0;
+      margin-left: auto;
+      color: #94a3b8;
+      transition: transform 0.15s;
+    }
+
+    .chevron.open {
+      transform: rotate(180deg);
+    }
+
+    .trace {
+      display: flex;
+      flex-direction: column;
+      gap: 6px;
+      margin-top: 6px;
+    }
+  `;
+
+  @property({ type: Array }) toolCalls: ToolCall[] = [];
+  /** Live mode — the bot is still working; show the current tool + spinner. */
+  @property({ type: Boolean }) live = false;
+
+  @state() private _expanded = false;
+
+  private _toggle(): void {
+    this._expanded = !this._expanded;
+  }
+
+  private _lineContent() {
+    const calls = this.toolCalls;
+    const running = [...calls].reverse().find((tc) => tc.status === "running");
+    const errorCount = calls.filter((tc) => tc.status === "error").length;
+
+    if (this.live && running) {
+      return html`
+        <span class="spinner" aria-hidden="true"></span>
+        <span class="label">${running.description ?? running.name}</span>
+      `;
+    }
+
+    return html`
+      <svg class="line-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+        <path d="M14.7 6.3a1 1 0 0 0 0 1.4l1.6 1.6a1 1 0 0 0 1.4 0l3.77-3.77a6 6 0 0 1-7.94 7.94l-6.91 6.91a2.12 2.12 0 0 1-3-3l6.91-6.91a6 6 0 0 1 7.94-7.94l-3.76 3.76z"/>
+      </svg>
+      <span class="label">${t("toolCalls.summary", { count: calls.length })}</span>
+      ${errorCount > 0
+        ? html`<span class="count-error">${t("toolCalls.failed", { count: errorCount })}</span>`
+        : nothing}
+    `;
+  }
+
+  render() {
+    if (this.toolCalls.length === 0) return nothing;
+
+    return html`
+      <button
+        class="line"
+        @click=${this._toggle}
+        aria-expanded=${this._expanded}
+        aria-label="${t("toolCalls.ariaToggle")}"
+      >
+        ${this._lineContent()}
+        <svg class="chevron ${this._expanded ? "open" : ""}" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+          <path d="M6 9l6 6 6-6"/>
+        </svg>
+      </button>
+
+      ${this._expanded
+        ? html`
+            <div class="trace">
+              ${this.toolCalls.map(
+                (tc) => html`<tool-call-card .toolCall=${tc}></tool-call-card>`,
+              )}
+            </div>
+          `
+        : nothing}
+    `;
+  }
+}

--- a/packages/ui/src/chat-ui/ToolCallCard.ts
+++ b/packages/ui/src/chat-ui/ToolCallCard.ts
@@ -1,0 +1,263 @@
+import { LitElement, html, css, nothing } from "lit";
+import { customElement, property, state } from "lit/decorators.js";
+import { t } from "i18next";
+import "../i18n/i18n";
+import type { ToolCall } from "@chativa/core";
+
+/**
+ * <tool-call-card> — a single tool invocation.
+ *
+ * Collapsed: one row with the tool name, a status chip
+ * (running / completed / error) and a chevron. Expanded: the invocation
+ * parameters plus the result or error payload. Errors expand automatically
+ * so failures are visible at a glance.
+ */
+@customElement("tool-call-card")
+export class ToolCallCard extends LitElement {
+  static override styles = css`
+    :host {
+      display: block;
+    }
+
+    .card {
+      border: 1px solid #e2e8f0;
+      border-radius: 10px;
+      background: #ffffff;
+      overflow: hidden;
+    }
+
+    .head {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      width: 100%;
+      padding: 8px 10px;
+      border: none;
+      background: transparent;
+      cursor: pointer;
+      font-family: inherit;
+      font-size: 0.78rem;
+      color: #1e293b;
+      text-align: left;
+    }
+
+    .head:hover {
+      background: #f8fafc;
+    }
+
+    .tool-icon {
+      width: 14px;
+      height: 14px;
+      flex-shrink: 0;
+      color: #64748b;
+    }
+
+    .name {
+      font-weight: 600;
+      font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+
+    .chip {
+      display: inline-flex;
+      align-items: center;
+      gap: 4px;
+      padding: 2px 8px;
+      border-radius: 999px;
+      border: 1px solid #e2e8f0;
+      font-size: 0.68rem;
+      font-weight: 500;
+      flex-shrink: 0;
+      margin-left: auto;
+    }
+
+    .chip.running {
+      color: #475569;
+    }
+
+    .chip.completed {
+      color: #15803d;
+      border-color: #bbf7d0;
+      background: #f0fdf4;
+    }
+
+    .chip.error {
+      color: #b91c1c;
+      border-color: #fecaca;
+      background: #fef2f2;
+    }
+
+    .chip svg {
+      width: 11px;
+      height: 11px;
+    }
+
+    .spinner {
+      width: 10px;
+      height: 10px;
+      border: 2px solid #e2e8f0;
+      border-top-color: #64748b;
+      border-radius: 50%;
+      animation: tool-card-spin 0.8s linear infinite;
+    }
+
+    @keyframes tool-card-spin {
+      to { transform: rotate(360deg); }
+    }
+
+    .chevron {
+      width: 14px;
+      height: 14px;
+      flex-shrink: 0;
+      color: #94a3b8;
+      transition: transform 0.15s;
+    }
+
+    .chevron.open {
+      transform: rotate(180deg);
+    }
+
+    .body {
+      padding: 0 10px 10px;
+      display: flex;
+      flex-direction: column;
+      gap: 8px;
+    }
+
+    .section-label {
+      font-size: 0.62rem;
+      font-weight: 600;
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
+      color: #94a3b8;
+      margin-bottom: 4px;
+    }
+
+    pre {
+      margin: 0;
+      padding: 8px 10px;
+      border: 1px solid #e2e8f0;
+      border-radius: 8px;
+      background: #f8fafc;
+      font-size: 0.7rem;
+      font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+      color: #334155;
+      white-space: pre-wrap;
+      word-break: break-word;
+      max-height: 200px;
+      overflow: auto;
+    }
+
+    .error-box {
+      padding: 8px 10px;
+      border: 1px solid #fecaca;
+      border-radius: 8px;
+      background: #fef2f2;
+      font-size: 0.72rem;
+      color: #b91c1c;
+      word-break: break-word;
+    }
+  `;
+
+  @property({ type: Object }) toolCall: ToolCall | null = null;
+
+  @state() private _expanded = false;
+  /** Once the user toggles manually, stop auto-expanding on error. */
+  private _userToggled = false;
+  private _autoExpandedFor: string | null = null;
+
+  protected override willUpdate(): void {
+    const tc = this.toolCall;
+    // Auto-expand failures once per invocation so errors are never hidden.
+    if (tc && tc.status === "error" && !this._userToggled && this._autoExpandedFor !== tc.id) {
+      this._autoExpandedFor = tc.id;
+      this._expanded = true;
+    }
+  }
+
+  private _toggle(): void {
+    this._userToggled = true;
+    this._expanded = !this._expanded;
+  }
+
+  private _renderChip(tc: ToolCall) {
+    if (tc.status === "running") {
+      return html`<span class="chip running"><span class="spinner"></span>${t("toolCalls.running")}</span>`;
+    }
+    if (tc.status === "error") {
+      return html`<span class="chip error">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round"><circle cx="12" cy="12" r="9" stroke-width="2"/><path d="M15 9l-6 6M9 9l6 6"/></svg>
+        ${t("toolCalls.error")}
+      </span>`;
+    }
+    return html`<span class="chip completed">
+      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="9" stroke-width="2"/><path d="M8.5 12.2l2.3 2.3 4.7-4.8"/></svg>
+      ${t("toolCalls.completed")}
+    </span>`;
+  }
+
+  private _pretty(value: unknown): string {
+    if (typeof value === "string") return value;
+    try {
+      return JSON.stringify(value, null, 2);
+    } catch {
+      return String(value);
+    }
+  }
+
+  render() {
+    const tc = this.toolCall;
+    if (!tc) return nothing;
+
+    const hasParams = tc.params !== undefined && Object.keys(tc.params).length > 0;
+    const hasResult = tc.status === "completed" && tc.result !== undefined;
+    const hasError = tc.status === "error" && !!tc.error;
+
+    return html`
+      <div class="card">
+        <button
+          class="head"
+          @click=${this._toggle}
+          aria-expanded=${this._expanded}
+          aria-label="${tc.name} — ${t(`toolCalls.${tc.status}`)}"
+        >
+          <svg class="tool-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+            <path d="M14.7 6.3a1 1 0 0 0 0 1.4l1.6 1.6a1 1 0 0 0 1.4 0l3.77-3.77a6 6 0 0 1-7.94 7.94l-6.91 6.91a2.12 2.12 0 0 1-3-3l6.91-6.91a6 6 0 0 1 7.94-7.94l-3.76 3.76z"/>
+          </svg>
+          <span class="name">${tc.name}</span>
+          ${this._renderChip(tc)}
+          <svg class="chevron ${this._expanded ? "open" : ""}" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+            <path d="M6 9l6 6 6-6"/>
+          </svg>
+        </button>
+
+        ${this._expanded
+          ? html`
+              <div class="body">
+                ${hasParams
+                  ? html`<div>
+                      <div class="section-label">${t("toolCalls.parameters")}</div>
+                      <pre>${this._pretty(tc.params)}</pre>
+                    </div>`
+                  : nothing}
+                ${hasResult
+                  ? html`<div>
+                      <div class="section-label">${t("toolCalls.result")}</div>
+                      <pre>${this._pretty(tc.result)}</pre>
+                    </div>`
+                  : nothing}
+                ${hasError
+                  ? html`<div>
+                      <div class="section-label">${t("toolCalls.error")}</div>
+                      <div class="error-box">${tc.error}</div>
+                    </div>`
+                  : nothing}
+              </div>
+            `
+          : nothing}
+      </div>
+    `;
+  }
+}

--- a/packages/ui/src/i18n/en.json
+++ b/packages/ui/src/i18n/en.json
@@ -1,85 +1,95 @@
 {
-    "greeting": "Hello",
-    "welcome": "Welcome, {{name}}!",
-    "header": {
-        "title": "Chativa Chatbot",
-        "status": {
-            "connecting": "Connecting…",
-            "connected": "Online",
-            "error": "Connection error",
-            "disconnected": "Disconnected",
-            "offline": "Offline"
-        },
-        "fullscreen": {
-            "enter": "Enter fullscreen",
-            "exit": "Exit fullscreen"
-        },
-        "close": "Close",
-        "minimize": "Minimize",
-        "search": {
-            "toggle": "Search",
-            "placeholder": "Search messages…",
-            "clear": "Clear search"
-        }
+  "greeting": "Hello",
+  "welcome": "Welcome, {{name}}!",
+  "header": {
+    "title": "Chativa Chatbot",
+    "status": {
+      "connecting": "Connecting…",
+      "connected": "Online",
+      "error": "Connection error",
+      "disconnected": "Disconnected",
+      "offline": "Offline"
     },
-    "input": {
-        "placeholder": "Type a message…",
-        "send": "Send message",
-        "emoji": "Emoji",
-        "attachFile": "Attach file",
-        "removeFile": "Remove {{name}}",
-        "dropHere": "Drop files here",
-        "dropHereSubtitle": "Release to attach"
+    "fullscreen": {
+      "enter": "Enter fullscreen",
+      "exit": "Exit fullscreen"
     },
-    "messageList": {
-        "connecting": "Connecting…",
-        "emptyTitle": "How can I help you?",
-        "emptySubtitle": "Send a message to get started.",
-        "newMessage": "New message",
-        "loadMore": "Load previous messages",
-        "errorTitle": "Connection lost",
-        "errorSubtitle": "We could not reconnect. Please try again.",
-        "retry": "Try again",
-        "reconnecting": "Reconnecting… (attempt {{attempt}})",
-        "searchEmpty": "No messages match your search.",
-        "searchResult": "{{count}} result(s) found",
-        "loadingHistory": "Loading previous messages…",
-        "ariaLabel": "Chat messages",
-        "typingIndicator": "Assistant is typing"
-    },
-    "message": {
-        "from": {
-            "bot": "Assistant",
-            "user": "You"
-        },
-        "likeButton": "Like this message",
-        "dislikeButton": "Dislike this message",
-        "statusSending": "Sending",
-        "statusSent": "Sent",
-        "statusRead": "Read"
-    },
-    "emojiPicker": {
-        "searchPlaceholder": "Search emoji…",
-        "noResults": "No results"
-    },
-    "chatButton": {
-        "open": "Open chat",
-        "close": "Close chat"
-    },
-    "widget": {
-        "title": "Chat"
-    },
-    "survey": {
-        "title": "How did we do?",
-        "ratingLabel": "Rate your experience",
-        "commentPlaceholder": "What could we do better?",
-        "commentRequired": "Please tell us what went wrong",
-        "submit": "Submit",
-        "skip": "Skip",
-        "thankYouTitle": "We received your feedback!",
-        "thankYouBody": "Thank you for your valuable thoughts and comments.",
-        "close": "Close",
-        "starLabel_one": "{{count}} star",
-        "starLabel_other": "{{count}} stars"
+    "close": "Close",
+    "minimize": "Minimize",
+    "search": {
+      "toggle": "Search",
+      "placeholder": "Search messages…",
+      "clear": "Clear search"
     }
+  },
+  "input": {
+    "placeholder": "Type a message…",
+    "send": "Send message",
+    "emoji": "Emoji",
+    "attachFile": "Attach file",
+    "removeFile": "Remove {{name}}",
+    "dropHere": "Drop files here",
+    "dropHereSubtitle": "Release to attach"
+  },
+  "messageList": {
+    "connecting": "Connecting…",
+    "emptyTitle": "How can I help you?",
+    "emptySubtitle": "Send a message to get started.",
+    "newMessage": "New message",
+    "loadMore": "Load previous messages",
+    "errorTitle": "Connection lost",
+    "errorSubtitle": "We could not reconnect. Please try again.",
+    "retry": "Try again",
+    "reconnecting": "Reconnecting… (attempt {{attempt}})",
+    "searchEmpty": "No messages match your search.",
+    "searchResult": "{{count}} result(s) found",
+    "loadingHistory": "Loading previous messages…",
+    "ariaLabel": "Chat messages",
+    "typingIndicator": "Assistant is typing"
+  },
+  "message": {
+    "from": {
+      "bot": "Assistant",
+      "user": "You"
+    },
+    "likeButton": "Like this message",
+    "dislikeButton": "Dislike this message",
+    "statusSending": "Sending",
+    "statusSent": "Sent",
+    "statusRead": "Read"
+  },
+  "emojiPicker": {
+    "searchPlaceholder": "Search emoji…",
+    "noResults": "No results"
+  },
+  "chatButton": {
+    "open": "Open chat",
+    "close": "Close chat"
+  },
+  "widget": {
+    "title": "Chat"
+  },
+  "survey": {
+    "title": "How did we do?",
+    "ratingLabel": "Rate your experience",
+    "commentPlaceholder": "What could we do better?",
+    "commentRequired": "Please tell us what went wrong",
+    "submit": "Submit",
+    "skip": "Skip",
+    "thankYouTitle": "We received your feedback!",
+    "thankYouBody": "Thank you for your valuable thoughts and comments.",
+    "close": "Close",
+    "starLabel_one": "{{count}} star",
+    "starLabel_other": "{{count}} stars"
+  },
+  "toolCalls": {
+    "running": "Running",
+    "completed": "Completed",
+    "error": "Error",
+    "parameters": "Parameters",
+    "result": "Result",
+    "summary": "{{count}} operation(s) performed",
+    "failed": "{{count}} failed",
+    "ariaToggle": "Toggle tool call details"
+  }
 }

--- a/packages/ui/src/i18n/tr.json
+++ b/packages/ui/src/i18n/tr.json
@@ -1,85 +1,95 @@
 {
-    "greeting": "Merhaba",
-    "welcome": "Hoş geldin, {{name}}!",
-    "header": {
-        "title": "Chativa Sohbet Botu",
-        "status": {
-            "connecting": "Bağlanıyor…",
-            "connected": "Çevrimiçi",
-            "error": "Bağlantı hatası",
-            "disconnected": "Bağlantı kesildi",
-            "offline": "Çevrimdışı"
-        },
-        "fullscreen": {
-            "enter": "Tam ekrana geç",
-            "exit": "Tam ekrandan çık"
-        },
-        "close": "Kapat",
-        "minimize": "Küçült",
-        "search": {
-            "toggle": "Ara",
-            "placeholder": "Mesaj ara…",
-            "clear": "Aramayı temizle"
-        }
+  "greeting": "Merhaba",
+  "welcome": "Hoş geldin, {{name}}!",
+  "header": {
+    "title": "Chativa Sohbet Botu",
+    "status": {
+      "connecting": "Bağlanıyor…",
+      "connected": "Çevrimiçi",
+      "error": "Bağlantı hatası",
+      "disconnected": "Bağlantı kesildi",
+      "offline": "Çevrimdışı"
     },
-    "input": {
-        "placeholder": "Bir mesaj yazın…",
-        "send": "Mesaj gönder",
-        "emoji": "Emoji",
-        "attachFile": "Dosya ekle",
-        "removeFile": "{{name}} kaldır",
-        "dropHere": "Dosyaları buraya bırakın",
-        "dropHereSubtitle": "Eklemek için bırakın"
+    "fullscreen": {
+      "enter": "Tam ekrana geç",
+      "exit": "Tam ekrandan çık"
     },
-    "messageList": {
-        "connecting": "Bağlanıyor…",
-        "emptyTitle": "Size nasıl yardımcı olabilirim?",
-        "emptySubtitle": "Başlamak için bir mesaj gönderin.",
-        "newMessage": "Yeni mesaj",
-        "loadMore": "Önceki mesajları yükle",
-        "errorTitle": "Bağlantı kesildi",
-        "errorSubtitle": "Yeniden bağlanılamadı. Lütfen tekrar deneyin.",
-        "retry": "Tekrar dene",
-        "reconnecting": "Yeniden bağlanıyor… (deneme {{attempt}})",
-        "searchEmpty": "Aramanızla eşleşen mesaj yok.",
-        "searchResult": "{{count}} sonuç bulundu",
-        "loadingHistory": "Önceki mesajlar yükleniyor…",
-        "ariaLabel": "Sohbet mesajları",
-        "typingIndicator": "Asistan yazıyor"
-    },
-    "message": {
-        "from": {
-            "bot": "Asistan",
-            "user": "Siz"
-        },
-        "likeButton": "Bu mesajı beğen",
-        "dislikeButton": "Bu mesajı beğenme",
-        "statusSending": "Gönderiliyor",
-        "statusSent": "Gönderildi",
-        "statusRead": "Okundu"
-    },
-    "emojiPicker": {
-        "searchPlaceholder": "Emoji ara…",
-        "noResults": "Sonuç yok"
-    },
-    "chatButton": {
-        "open": "Sohbeti aç",
-        "close": "Sohbeti kapat"
-    },
-    "widget": {
-        "title": "Sohbet"
-    },
-    "survey": {
-        "title": "Görüşmemizi değerlendirir misiniz?",
-        "ratingLabel": "Deneyiminizi puanlayın",
-        "commentPlaceholder": "Neyi daha iyi yapabiliriz?",
-        "commentRequired": "Lütfen neyin yanlış gittiğini yazın",
-        "submit": "Gönder",
-        "skip": "Atla",
-        "thankYouTitle": "Değerlendirmeni Aldık!",
-        "thankYouBody": "Değerli görüş ve yorumların için teşekkür ederiz.",
-        "close": "Kapat",
-        "starLabel_one": "{{count}} yıldız",
-        "starLabel_other": "{{count}} yıldız"
+    "close": "Kapat",
+    "minimize": "Küçült",
+    "search": {
+      "toggle": "Ara",
+      "placeholder": "Mesaj ara…",
+      "clear": "Aramayı temizle"
     }
+  },
+  "input": {
+    "placeholder": "Bir mesaj yazın…",
+    "send": "Mesaj gönder",
+    "emoji": "Emoji",
+    "attachFile": "Dosya ekle",
+    "removeFile": "{{name}} kaldır",
+    "dropHere": "Dosyaları buraya bırakın",
+    "dropHereSubtitle": "Eklemek için bırakın"
+  },
+  "messageList": {
+    "connecting": "Bağlanıyor…",
+    "emptyTitle": "Size nasıl yardımcı olabilirim?",
+    "emptySubtitle": "Başlamak için bir mesaj gönderin.",
+    "newMessage": "Yeni mesaj",
+    "loadMore": "Önceki mesajları yükle",
+    "errorTitle": "Bağlantı kesildi",
+    "errorSubtitle": "Yeniden bağlanılamadı. Lütfen tekrar deneyin.",
+    "retry": "Tekrar dene",
+    "reconnecting": "Yeniden bağlanıyor… (deneme {{attempt}})",
+    "searchEmpty": "Aramanızla eşleşen mesaj yok.",
+    "searchResult": "{{count}} sonuç bulundu",
+    "loadingHistory": "Önceki mesajlar yükleniyor…",
+    "ariaLabel": "Sohbet mesajları",
+    "typingIndicator": "Asistan yazıyor"
+  },
+  "message": {
+    "from": {
+      "bot": "Asistan",
+      "user": "Siz"
+    },
+    "likeButton": "Bu mesajı beğen",
+    "dislikeButton": "Bu mesajı beğenme",
+    "statusSending": "Gönderiliyor",
+    "statusSent": "Gönderildi",
+    "statusRead": "Okundu"
+  },
+  "emojiPicker": {
+    "searchPlaceholder": "Emoji ara…",
+    "noResults": "Sonuç yok"
+  },
+  "chatButton": {
+    "open": "Sohbeti aç",
+    "close": "Sohbeti kapat"
+  },
+  "widget": {
+    "title": "Sohbet"
+  },
+  "survey": {
+    "title": "Görüşmemizi değerlendirir misiniz?",
+    "ratingLabel": "Deneyiminizi puanlayın",
+    "commentPlaceholder": "Neyi daha iyi yapabiliriz?",
+    "commentRequired": "Lütfen neyin yanlış gittiğini yazın",
+    "submit": "Gönder",
+    "skip": "Atla",
+    "thankYouTitle": "Değerlendirmeni Aldık!",
+    "thankYouBody": "Değerli görüş ve yorumların için teşekkür ederiz.",
+    "close": "Kapat",
+    "starLabel_one": "{{count}} yıldız",
+    "starLabel_other": "{{count}} yıldız"
+  },
+  "toolCalls": {
+    "running": "Çalışıyor",
+    "completed": "Tamamlandı",
+    "error": "Hata",
+    "parameters": "Parametreler",
+    "result": "Sonuç",
+    "summary": "{{count}} işlem yapıldı",
+    "failed": "{{count}} hatalı",
+    "ariaToggle": "İşlem detaylarını aç/kapat"
+  }
 }

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -33,12 +33,16 @@ import "./chat-ui/ConversationList";
 import "./chat-ui/AgentPanel";
 import "./chat-ui/EndOfConversationSurvey";
 import "./chat-ui/LinkPreviewCard";
+import "./chat-ui/ToolCallCard";
+import "./chat-ui/ToolCallActivity";
 
 import { MessageTypeRegistry } from "@chativa/core";
 import { EndOfConversationSurvey } from "./chat-ui/EndOfConversationSurvey";
 export { EndOfConversationSurvey } from "./chat-ui/EndOfConversationSurvey";
 export { LinkPreviewCard } from "./chat-ui/LinkPreviewCard";
 export type { LinkMetadata, LinkMetadataFetcher } from "./chat-ui/LinkPreviewCard";
+export { ToolCallCard } from "./chat-ui/ToolCallCard";
+export { ToolCallActivity } from "./chat-ui/ToolCallActivity";
 MessageTypeRegistry.register(
   "end-of-conversation-survey",
   EndOfConversationSurvey as unknown as typeof HTMLElement,

--- a/schemas/messages/tool-call.schema.json
+++ b/schemas/messages/tool-call.schema.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://chativa.aimtune.dev/schemas/messages/tool-call.schema.json",
+  "title": "ToolCall",
+  "description": "A single tool invocation reported by a connector via IConnector.onToolCall(). Connectors emit the same `id` multiple times as the call progresses (running -> completed/error); consumers upsert by `id`. Over WebSocket this travels as a `{ \"type\": \"tool_call\", \"data\": { ...ToolCall } }` frame. Source: packages/core/src/domain/entities/ToolCall.ts.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["id", "name", "status"],
+  "properties": {
+    "id":          { "type": "string", "description": "Unique id for this invocation (e.g. an Anthropic `tool_use` id)." },
+    "name":        { "type": "string", "description": "Tool name, e.g. \"get_weather\"." },
+    "description": { "type": "string", "description": "Human-readable description of what the tool is doing, shown in the activity line." },
+    "status":      { "type": "string", "enum": ["running", "completed", "error"], "description": "Lifecycle state of the invocation." },
+    "params":      { "type": "object", "description": "Input parameters the tool was invoked with." },
+    "result":      { "description": "Result payload — present once status is \"completed\". Any JSON value." },
+    "error":       { "type": "string", "description": "Error message — present once status is \"error\"." },
+    "startedAt":   { "type": "number", "description": "Epoch ms when the call started." },
+    "endedAt":     { "type": "number", "description": "Epoch ms when the call settled (completed or error)." }
+  }
+}


### PR DESCRIPTION
## Summary

Connectors can now report agent/LLM tool invocations as **lifecycle events** instead of printing them as plain chat messages (the previous pattern, e.g. `🔧 tool_name({...})` text frames). The trace renders as a compact one-line activity strip that expands into per-call cards with parameters, result, and error details.

### Flow

1. A connector emits `ToolCall` events via the new optional `IConnector.onToolCall` port (`running → completed/error`, upsert-by-id).
2. `ChatEngine` collects them in `chatStore.activeToolCalls`; the message list shows a **live strip** (spinner + current tool's description) above the typing indicator while the bot works.
3. When the reply arrives — a plain message **or a GenUI stream** — the trace attaches to `data.toolCalls` and the buffer clears. The attached trace renders as a "N operation(s) performed" line **right above the message**, expandable to full `<tool-call-card>`s (status chip, Parameters JSON, Result / red Error box; errors auto-expand).

### Changes

- **core** — `ToolCall` entity, `IConnector.onToolCall` port, `tool_call_updated` EventBus event, `ChatStore.upsertToolCall/clearToolCalls`, ChatEngine attach-and-clear for both `onMessage` replies and GenUI streams. Fixes a latent bug: GenUI chunk updates replaced the whole `data` record, wiping extra fields — now prior fields are preserved.
- **ui** — new `<tool-call-card>` and `<tool-call-activity>` components; ChatMessageList renders the trace **at list level**, so every message type gets it — built-in or custom (e.g. a GenUI weather widget). en/tr i18n.
- **connector-websocket** — routes incoming `{type:"tool_call", data:{...}}` frames to `onToolCall`.
- **connector-dummy** — `triggerToolCalls("success" | "error" | "multi" | "genui")` demo scenarios + `/tools`, `/tools-error` chat commands.
- **schemas** — `messages/tool-call.schema.json` documents the wire payload.
- **sandbox** — 🔧 demo buttons (including a tools→GenUI weather finale), `window.chativaToolDemo`, genui paths mapping in tsconfig for dist-less typecheck.

## Test plan

- [x] `pnpm test` — 349 passing (+15 new: ChatStore upsert/merge/clear/reset, ChatEngine collect/attach/clear + connector-supplied precedence + GenUI attach surviving chunk updates, DummyConnector scenario sequences)
- [x] `pnpm typecheck` + sandbox `tsc --noEmit`, verified CI-style with all `dist/` folders hidden
- [ ] Manual: sandbox 🔧 demo buttons and `/tools` command — live strip, expandable trace, error card, GenUI weather finale

🤖 Generated with [Claude Code](https://claude.com/claude-code)