### PR TITLE
feat(genui): visual consistency — shared bubbles, global font, rating fit

### DIFF
--- a/docs/theming.md
+++ b/docs/theming.md
@@ -22,6 +22,40 @@ chat-iva {
 
 The store's `setTheme()` ultimately writes these same variables via `themeToCSS()`.
 
+## Fonts
+
+Every Chativa surface (widget, conversation list, agent panel, GenUI
+components) resolves its typeface from one variable:
+
+```css
+chat-iva {
+  --chativa-font-family: "Inter", sans-serif;   /* global override */
+}
+```
+
+Unset, it falls back to the system font stack. Individual components can be
+overridden with their own variable where offered — e.g.
+`--chativa-typewriter-font` for `<genui-typewriter>`.
+
+Custom GenUI components inherit the widget font automatically as long as
+they don't set `font-family` themselves (or set it to `inherit`). To render
+text that looks like a regular bot bubble inside a custom component, compose
+the shared style:
+
+```ts
+import { bubbleStyles } from "@chativa/genui";
+
+class MyComponent extends ChativaElement {
+  static styles = [bubbleStyles, css`/* own styles */`];
+  render() {
+    return html`<div class="chativa-bubble">${this.text}</div>`;
+  }
+}
+```
+
+Or simply emit a `genui-text` chunk from the connector — it renders with the
+same bubble.
+
 ## ThemeConfig
 
 Full schema: [`schemas/theme.schema.json`](../schemas/theme.schema.json). Field-by-field reference: [configuration.md → ThemeConfig](./configuration.md#themeconfig).

--- a/packages/genui/src/components/GenUIMessage.ts
+++ b/packages/genui/src/components/GenUIMessage.ts
@@ -3,6 +3,7 @@ import { customElement, property } from "lit/decorators.js";
 import type { GenUIStreamState, AIChunk, AIChunkText, AIChunkUI, AIChunkEvent } from "@chativa/core";
 import { ChativaElement, MessageTypeRegistry, chatStore, i18next, t } from "@chativa/core";
 import { GenUIRegistry } from "../registry/GenUIRegistry";
+import { bubbleStyles } from "../styles/bubble";
 
 // ── Types ─────────────────────────────────────────────────────────────────────
 
@@ -15,7 +16,7 @@ interface EventListener {
 
 @customElement("genui-message")
 export class GenUIMessage extends ChativaElement {
-  static override styles = css`
+  static override styles = [bubbleStyles, css`
     :host {
       display: block;
       width: 100%;
@@ -65,7 +66,14 @@ export class GenUIMessage extends ChativaElement {
       gap: 3px;
       flex: 1;
       min-width: 0;
+      /* Single inheritance point for the whole GenUI subtree — built-in and
+         custom components pick this up unless they override it themselves. */
+      font-family: var(--chativa-font-family, inherit);
     }
+
+    /* Text chunks render as regular bot bubbles (shared chativa-bubble
+       look from ../styles/bubble) so mixed text + component streams read
+       like one conversation. */
 
     .genui-wrapper {
       display: flex;
@@ -139,7 +147,7 @@ export class GenUIMessage extends ChativaElement {
       font-size: 0.8125rem;
       font-family: inherit;
     }
-  `;
+  `];
 
   // ── Props passed by ChatMessageList ───────────────────────────────────────
 
@@ -196,14 +204,10 @@ export class GenUIMessage extends ChativaElement {
   // ── Chunk rendering ───────────────────────────────────────────────────────
 
   private _renderTextChunk(chunk: AIChunkText) {
-    // Inline markdown rendering without depending on marked at runtime in genui.
-    // We use unsafeHTML only if the content contains markdown markers.
-    const raw = chunk.content;
-    return html`
-      <div class="chunk-enter" style="font-size:0.875rem;line-height:1.6;color:#0f172a;white-space:pre-wrap;">
-        ${raw}
-      </div>
-    `;
+    // NOTE: `${chunk.content}` must stay flush against the tags — the div is
+    // white-space:pre-wrap, so template indentation would render literally
+    // as leading spaces.
+    return html`<div class="chunk-enter chativa-bubble">${chunk.content}</div>`;
   }
 
   private _renderUIChunk(chunk: AIChunkUI) {

--- a/packages/genui/src/components/GenUIRating.ts
+++ b/packages/genui/src/components/GenUIRating.ts
@@ -42,18 +42,22 @@ export class GenUIRating extends ChativaElement {
     .stars {
       display: flex;
       justify-content: center;
-      gap: 6px;
-      margin-bottom: 14px;
+      flex-wrap: wrap;
+      gap: 4px;
+      /* Breathing room so the hover scale-up never clips or spills
+         past the card edge. */
+      padding: 4px 6px;
+      margin-bottom: 10px;
     }
 
     .star {
-      font-size: 2rem;
+      font-size: 1.75rem;
       cursor: pointer;
       transition: transform 0.1s ease, opacity 0.1s;
-      line-height: 1;
+      line-height: 1.2;
       border: none;
       background: none;
-      padding: 0;
+      padding: 2px 3px;
       opacity: 0.3;
       user-select: none;
     }

--- a/packages/genui/src/components/GenUITextBlock.ts
+++ b/packages/genui/src/components/GenUITextBlock.ts
@@ -1,29 +1,27 @@
 import { html, css } from "lit";
 import { customElement, property } from "lit/decorators.js";
 import { ChativaElement } from "@chativa/core";
+import { bubbleStyles } from "../styles/bubble";
 
 /**
- * `<genui-text-block>` — built-in plain-text/markdown chunk renderer.
- * Used automatically by GenUIMessage for `{ type: "text" }` chunks.
+ * `<genui-text-block>` — built-in plain-text chunk renderer, drawn as a
+ * regular bot bubble. Available to connectors as `genui-text` and to
+ * custom components for composing text into their own templates.
  */
 @customElement("genui-text-block")
 export class GenUITextBlock extends ChativaElement {
-  static override styles = css`
-    :host {
-      display: block;
-    }
-    .content {
-      font-size: 0.875rem;
-      line-height: 1.65;
-      color: #0f172a;
-      white-space: pre-wrap;
-      word-break: break-word;
-    }
-  `;
+  static override styles = [
+    bubbleStyles,
+    css`
+      :host {
+        display: block;
+      }
+    `,
+  ];
 
   @property({ type: String }) content = "";
 
   override render() {
-    return html`<div class="content">${this.content}</div>`;
+    return html`<div class="chativa-bubble">${this.content}</div>`;
   }
 }

--- a/packages/genui/src/components/GenUITypewriter.ts
+++ b/packages/genui/src/components/GenUITypewriter.ts
@@ -1,6 +1,7 @@
 import { html, css, nothing } from "lit";
 import { customElement, property, state } from "lit/decorators.js";
 import { ChativaElement } from "@chativa/core";
+import { bubbleStyles } from "../styles/bubble";
 
 /**
  * GenUITypewriter — animates text content character by character.
@@ -17,24 +18,34 @@ import { ChativaElement } from "@chativa/core";
  */
 @customElement("genui-typewriter")
 export class GenUITypewriter extends ChativaElement {
-  static override styles = css`
-    :host {
-      display: inline;
-    }
+  static override styles = [
+    bubbleStyles,
+    css`
+      :host {
+        display: block;
+      }
 
-    .cursor {
-      display: inline-block;
-      font-weight: 300;
-      animation: blink 1s step-end infinite;
-      margin-left: 1px;
-      opacity: 1;
-    }
+      /* The typewriting happens inside a regular bot bubble. Override the
+         font per component with --chativa-typewriter-font, or globally
+         with --chativa-font-family. */
+      .chativa-bubble {
+        font-family: var(--chativa-typewriter-font, var(--chativa-font-family, inherit));
+      }
 
-    @keyframes blink {
-      0%, 100% { opacity: 1; }
-      50%       { opacity: 0; }
-    }
-  `;
+      .cursor {
+        display: inline-block;
+        font-weight: 300;
+        animation: blink 1s step-end infinite;
+        margin-left: 1px;
+        opacity: 1;
+      }
+
+      @keyframes blink {
+        0%, 100% { opacity: 1; }
+        50%       { opacity: 0; }
+      }
+    `,
+  ];
 
   /** Full text to animate. */
   @property({ type: String }) content = "";
@@ -79,6 +90,6 @@ export class GenUITypewriter extends ChativaElement {
   override render() {
     const complete = this._displayed.length >= this.content.length;
     const showCursor = this.cursor !== false && !complete;
-    return html`<span>${this._displayed}</span>${showCursor ? html`<span class="cursor">|</span>` : nothing}`;
+    return html`<div class="chativa-bubble"><span>${this._displayed}</span>${showCursor ? html`<span class="cursor">|</span>` : nothing}</div>`;
   }
 }

--- a/packages/genui/src/components/__tests__/GenUITextBlock.test.ts
+++ b/packages/genui/src/components/__tests__/GenUITextBlock.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect, beforeAll } from "vitest";
+import "../GenUITextBlock";
+
+describe("GenUITextBlock", () => {
+  beforeAll(() => {
+    if (!customElements.get("genui-text-block")) {
+      throw new Error("Custom element not registered");
+    }
+  });
+
+  it("renders the content inside the shared bubble", async () => {
+    const el = document.createElement("genui-text-block") as HTMLElement & {
+      content: string;
+    };
+    el.content = "Hello from the stream";
+    document.body.appendChild(el);
+    await new Promise((r) => setTimeout(r, 0));
+
+    const bubble = el.shadowRoot?.querySelector(".chativa-bubble");
+    expect(bubble).not.toBeNull();
+    expect(bubble?.textContent).toContain("Hello from the stream");
+    el.remove();
+  });
+
+  it("preserves newlines via pre-wrap without inheriting template whitespace", async () => {
+    const el = document.createElement("genui-text-block") as HTMLElement & {
+      content: string;
+    };
+    el.content = "line 1\nline 2";
+    document.body.appendChild(el);
+    await new Promise((r) => setTimeout(r, 0));
+
+    // The bubble must contain exactly the content — no leading indentation
+    // leaked from the Lit template (the div is white-space: pre-wrap).
+    expect(el.shadowRoot?.querySelector(".chativa-bubble")?.textContent).toBe(
+      "line 1\nline 2",
+    );
+    el.remove();
+  });
+});

--- a/packages/genui/src/index.ts
+++ b/packages/genui/src/index.ts
@@ -39,6 +39,11 @@ export { GenUITypewriter } from "./components/GenUITypewriter";
 // ── Utilities ─────────────────────────────────────────────────────────────────
 export { streamFromFetch } from "./utils/streamFromFetch";
 
+// ── Shared styles ─────────────────────────────────────────────────────────────
+// Chat-bubble look for text content — custom components compose it via
+// `static styles = [bubbleStyles, ...]` + class="chativa-bubble".
+export { bubbleStyles } from "./styles/bubble";
+
 // ── Re-export core GenUI types for convenience ────────────────────────────────
 export type {
   AIChunk,

--- a/packages/genui/src/styles/bubble.ts
+++ b/packages/genui/src/styles/bubble.ts
@@ -1,0 +1,38 @@
+import { css } from "lit";
+
+/**
+ * Shared chat-bubble look for text content inside GenUI streams.
+ *
+ * Apply the `chativa-bubble` class to the element that holds the text.
+ * Used by the built-in text chunk renderer, `<genui-text-block>` and
+ * `<genui-typewriter>`; custom components can opt in the same way:
+ *
+ * ```ts
+ * import { bubbleStyles } from "@chativa/genui";
+ *
+ * class MyComponent extends ChativaElement {
+ *   static styles = [bubbleStyles, css`...`];
+ *   render() { return html`<div class="chativa-bubble">${this.text}</div>`; }
+ * }
+ * ```
+ *
+ * The font follows the widget: `--chativa-font-family` overrides it
+ * globally, and a component can override just itself by re-declaring
+ * `font-family` after these styles.
+ */
+export const bubbleStyles = css`
+  .chativa-bubble {
+    background: #f1f5f9;
+    color: #0f172a;
+    border-radius: 4px 16px 16px 16px;
+    padding: 9px 13px;
+    font-family: var(--chativa-font-family, inherit);
+    font-size: 0.875rem;
+    line-height: 1.5;
+    white-space: pre-wrap;
+    word-break: break-word;
+    width: fit-content;
+    max-width: 100%;
+    box-sizing: border-box;
+  }
+`;

--- a/packages/ui/src/chat-ui/AgentPanel.ts
+++ b/packages/ui/src/chat-ui/AgentPanel.ts
@@ -34,7 +34,7 @@ export class AgentPanel extends LitElement {
       flex-direction: column;
       width: 100%;
       height: 100%;
-      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+      font-family: var(--chativa-font-family, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif);
       background: white;
       border-radius: 12px;
       overflow: hidden;

--- a/packages/ui/src/chat-ui/ChatWidget.ts
+++ b/packages/ui/src/chat-ui/ChatWidget.ts
@@ -72,7 +72,7 @@ export class ChatWidget extends ChatbotMixin(LitElement) {
       overflow: hidden;
       animation: slideUp 0.28s cubic-bezier(0.34, 1.56, 0.64, 1);
       z-index: 9999;
-      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+      font-family: var(--chativa-font-family, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif);
       transition: border-radius 0.25s ease, box-shadow 0.25s ease;
     }
 

--- a/packages/ui/src/chat-ui/ConversationList.ts
+++ b/packages/ui/src/chat-ui/ConversationList.ts
@@ -20,7 +20,7 @@ export class ConversationList extends LitElement {
       height: 100%;
       background: #f8fafc;
       border-right: 1px solid #e2e8f0;
-      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+      font-family: var(--chativa-font-family, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif);
       min-width: 0;
     }
 


### PR DESCRIPTION
## Summary

Stacked on #23 (retarget to `main` after it merges).

- **Shared `bubbleStyles`** (`packages/genui/src/styles/bubble.ts`, exported from `@chativa/genui`): one `chativa-bubble` fragment now backs GenUIMessage text chunks, `genui-text-block`, and `genui-typewriter` — the typewriter animates inside a regular bot bubble instead of bare inline text. Custom components can compose the same bubble via `static styles = [bubbleStyles, ...]`.
- **Leading-whitespace fix**: template indentation no longer leaks into `white-space: pre-wrap` text chunks (the `"        Here's the current status…"` artifact), with a regression test.
- **Global font override**: ChatWidget/ConversationList/AgentPanel resolve their stack through `var(--chativa-font-family, <system stack>)`; GenUI subtree inherits it, `--chativa-typewriter-font` overrides per component. Documented in `docs/theming.md` → Fonts.
- **Rating stars** no longer clip/spill on hover: padded star row, slightly smaller glyph, wrap on long rows.

## Test plan

- [x] genui 59/59 (2 new: bubble render + whitespace regression), full workspace suite 366 tests green
- [x] `pnpm typecheck` across all packages

🤖 Generated with [Claude Code](https://claude.com/claude-code)