### PR TITLE
feat(genui): server-defined components, and buttons that say who they're for

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -200,7 +200,14 @@ export class MyConnector implements IConnector {
     this.genUICallback = callback;
   }
 
-  receiveComponentEvent(streamId: string, eventType: string, payload: unknown): void { }
+  // `opts` carries the interaction's routing metadata (`scope`, `component`) for
+  // protocols that model it; ignoring it is fine.
+  receiveComponentEvent(
+    streamId: string,
+    eventType: string,
+    payload: unknown,
+    opts?: GenUIEventOptions,
+  ): void { }
 }
 ```
 
@@ -288,54 +295,47 @@ MessageTypeRegistry.register("my-type", MyMessage);
 ## When Creating a New GenUI Component
 
 1. Create `packages/genui/src/components/[Name].ts`
-2. Extend `LitElement` (not ChatbotMixin — GenUI components are standalone)
-3. Declare optional `GenUIComponentAPI` properties to receive injected methods
-4. Self-register in `GenUIRegistry`
-5. Add tests
+2. Extend `GenUIElement` from `@chativa/core` (not ChatbotMixin — GenUI components are standalone)
+3. Self-register in `GenUIRegistry`
+4. Add tests
+
+`GenUIElement` extends `ChativaElement` (i18n + auto re-render on locale switch) and implements the full
+`GenUIComponentAPI` with working defaults, so `this.sendEvent(...)`, `this.listenEvent(...)` and
+`this.tFn(...)` are always callable. `GenUIMessage` shadows them with message-scoped versions at mount
+time. Do NOT redeclare those four as class fields — that shadows the defaults with `undefined`.
 
 **Template:**
 ```ts
-import { LitElement, html, css } from "lit";
+import { html, css } from "lit";
 import { customElement, property } from "lit/decorators.js";
+import { GenUIElement } from "@chativa/core";
 import { GenUIRegistry } from "../registry/GenUIRegistry";
-import type { GenUIComponentAPI } from "../types";
 
 @customElement("my-genui-widget")
-export class MyGenUIWidget extends LitElement {
-  // Injected by GenUIMessage at render time
-  sendEvent?: GenUIComponentAPI["sendEvent"];
-  listenEvent?: GenUIComponentAPI["listenEvent"];
-  tFn?: GenUIComponentAPI["tFn"];
-  onLangChange?: GenUIComponentAPI["onLangChange"];
-
-  @property({ type: String }) title = "";
-
-  private _unsubLang?: () => void;
-
-  connectedCallback() {
-    super.connectedCallback();
-    this._unsubLang = this.onLangChange?.(() => this.requestUpdate());
-  }
-
-  disconnectedCallback() {
-    super.disconnectedCallback();
-    this._unsubLang?.();
-  }
-
-  static styles = css`
+export class MyGenUIWidget extends GenUIElement {
+  static override styles = css`
     :host { display: block; }
   `;
 
-  private _handleAction() {
-    this.sendEvent?.("widget_action", { title: this.title });
+  @property({ type: String }) title = "";
+
+  override connectedCallback() {
+    super.connectedCallback();
+    // Server-pushed event chunks targeting this component
+    this.listenEvent("widget_updated", (payload) => {
+      this.title = (payload as { title: string }).title;
+    });
   }
 
-  render() {
-    const label = this.tFn?.("widget.submit", "Submit") ?? "Submit";
+  private _handleAction() {
+    this.sendEvent("widget_action", { title: this.title });
+  }
+
+  override render() {
     return html`
       <div>
         <h3>${this.title}</h3>
-        <button @click=${this._handleAction}>${label}</button>
+        <button @click=${this._handleAction}>${this.tFn("widget.submit", "Submit")}</button>
       </div>
     `;
   }
@@ -344,6 +344,25 @@ export class MyGenUIWidget extends LitElement {
 // Self-register
 GenUIRegistry.register("my-widget", MyGenUIWidget);
 ```
+
+### Backend-authored components — `<chativa-html>`
+
+When the markup should come from the backend instead of a compiled widget, stream the built-in
+`GenUIHtmlElement` (registered as both `genui-html` and `html`):
+
+```json
+{ "type": "ui", "component": "html",
+  "props": { "html": "<button data-event='track' data-payload='{\"id\":1}'>Track</button>",
+             "css":  "button { border-radius: 8px; }" } }
+```
+
+Markup is sanitized by default (`sanitizeHtml` — drops `<script>`/`<iframe>`, `on*` attributes and
+`javascript:` URLs); the `unsafe` prop opts out. Clicks and form submits round-trip to
+`IConnector.receiveComponentEvent`. Three attributes trigger one, and which one you write says who
+the interaction is addressed to: `component-event` (scope `"component"` — the widget's own
+conversation with the backend node that mounted it), `mekik-event` (scope `"graph"` — the app),
+`data-event` (no scope — the backend decides). Most specific wins. Outside a `GenUIMessage` the
+element dispatches a bubbling, composed `genui-component-event` instead.
 
 ---
 

--- a/docs/genui/built-in.md
+++ b/docs/genui/built-in.md
@@ -18,6 +18,7 @@ Auto-registered by importing `@chativa/genui`.
 | `genui-steps` | Vertical step list | `steps: { label, status, description? }[]` | — |
 | `genui-image-gallery` | Grid of images | `columns?, images: { src, alt?, caption? }[]` | — |
 | `genui-appointment-form` | Specialised appointment form | `fields[]` | `form_submit` |
+| `genui-html` / `html` | Backend-authored raw markup ([details](./custom-component.md)) | `html: string, css?: string, unsafe?: boolean` | any `component-event` / `mekik-event` / `data-event` on a clicked element or submitted `<form>` |
 
 ## Visual reference
 

--- a/docs/genui/custom-component.md
+++ b/docs/genui/custom-component.md
@@ -1,87 +1,297 @@
 # Custom GenUI Component
 
-Anything you can build as a LitElement can be a GenUI component. Register it once; bots can stream it forever.
+Two ways to get your own UI into a chat bubble:
+
+| | Use when |
+|---|---|
+| **Extend `GenUIElement`** | You ship a compiled widget with the frontend. Full LitElement power, typed props. |
+| **Stream `<chativa-html>`** | The markup comes from the backend, a CMS, or a React app. No client-side build step, no redeploy to add a widget. |
+| **Let the server define it** (mekik) | The backend owns the whole widget and announces it on connect. Adding a widget is a server deploy. |
+
+Both live in `@chativa/core`, so a widget package doesn't have to depend on `@chativa/genui`.
+
+## 1. Extend `GenUIElement`
+
+`GenUIElement` extends `ChativaElement` (i18n + auto re-render on locale switch) and implements the whole `GenUIComponentAPI` with working defaults. You call `this.sendEvent(...)` / `this.listenEvent(...)` / `this.tFn(...)` directly — no optional chaining, no injected-property boilerplate.
 
 ```ts
-import { LitElement, html, css } from "lit";
+import { GenUIElement } from "@chativa/core";
+import { GenUIRegistry } from "@chativa/genui";
+import { html, css } from "lit";
 import { customElement, property } from "lit/decorators.js";
-import { GenUIRegistry, type GenUIComponentAPI } from "@chativa/genui";
 
 @customElement("weather-widget")
-export class WeatherWidget extends LitElement {
-  // Injected by GenUIMessage at mount time:
-  sendEvent?: GenUIComponentAPI["sendEvent"];
-  listenEvent?: GenUIComponentAPI["listenEvent"];
-  tFn?: GenUIComponentAPI["tFn"];
-  onLangChange?: GenUIComponentAPI["onLangChange"];
-
-  @property({ type: String })  city = "";
-  @property({ type: Number })  temp = 0;
-  @property({ type: String })  condition = "";
-
-  private _unsubLang?: () => void;
-
-  connectedCallback() {
-    super.connectedCallback();
-    // Re-render on locale switch so tFn returns the new language
-    this._unsubLang = this.onLangChange?.(() => this.requestUpdate());
-  }
-
-  disconnectedCallback() {
-    super.disconnectedCallback();
-    this._unsubLang?.();
-  }
-
-  static styles = css`
+export class WeatherWidget extends GenUIElement {
+  static override styles = css`
     :host { display: block; }
-    .card {
-      border: 1px solid var(--chativa-border-color);
-      border-radius: 12px; padding: 12px;
-    }
+    .card { border: 1px solid var(--chativa-border-color); border-radius: 12px; padding: 12px; }
   `;
 
-  private _refresh() {
-    // Echo back to the connector — connector receives this via receiveComponentEvent
-    this.sendEvent?.("refresh_weather", { city: this.city });
+  @property({ type: String }) city = "";
+  @property({ type: Number }) temp = 0;
+
+  override connectedCallback() {
+    super.connectedCallback();
+    // Server-pushed event chunks targeting this component
+    this.listenEvent("weather_updated", (p) => {
+      this.temp = (p as { temp: number }).temp;
+    });
   }
 
-  render() {
-    const refresh = this.tFn?.("widget.refresh", "Refresh") ?? "Refresh";
+  override render() {
     return html`
       <div class="card">
         <h3>${this.city}</h3>
-        <p>${this.temp}°C · ${this.condition}</p>
-        <button @click=${this._refresh}>${refresh}</button>
+        <p>${this.temp}°C</p>
+        <button @click=${() => this.sendEvent("refresh_weather", { city: this.city })}>
+          ${this.tFn("widget.refresh", "Refresh")}
+        </button>
       </div>
     `;
   }
 }
 
-// Side-effect register
 GenUIRegistry.register("weather", WeatherWidget);
 ```
 
-Then a connector can stream it as `{ type: "ui", component: "weather", props: { city, temp, condition } }`.
+The connector then streams `{ type: "ui", component: "weather", props: { city, temp } }`.
+
+**Don't redeclare** `sendEvent` / `listenEvent` / `tFn` / `onLangChange` as class fields — that shadows the base implementations with `undefined`. The old pattern (extending `LitElement` and declaring the four optional fields) still works; it's just boilerplate you no longer need.
+
+## 2. Stream raw markup with `<chativa-html>`
+
+Registered out of the box under `genui-html` and `html`, so a backend can ship the markup itself:
+
+```json
+{
+  "type": "ui",
+  "component": "html",
+  "props": {
+    "html": "<div class='card'><h3>Order #123</h3><button data-event='track_order' data-payload='{\"id\":123}'>Track</button></div>",
+    "css": ".card { border: 1px solid #e2e8f0; border-radius: 12px; padding: 12px; }"
+  }
+}
+```
+
+The click reaches your connector as `receiveComponentEvent(streamId, "track_order", { id: 123 })` — the same round trip a compiled component gets.
+
+### Props
+
+| Prop | Meaning |
+|---|---|
+| `html` | Markup to render. Sanitized unless `unsafe` is set. When empty, light-DOM children are rendered instead. |
+| `css` | CSS injected into the element's shadow root — scoped, so it can't leak into the page. |
+| `unsafe` | Skip sanitization. Only for markup you fully control. |
+
+### Interaction contract
+
+A click — or a form submit — on an element carrying an event attribute sends that
+event. Which attribute you use says **who the interaction is addressed to**, for
+backends that model the distinction (mekik `PROTOCOL.md` §10.4):
+
+| attribute | `scope` sent | meaning |
+| --- | --- | --- |
+| `component-event="<name>"` | `"component"` | the widget's own conversation with the graph node that mounted it — only a node waiting for that event name receives it |
+| `mekik-event="<name>"` | `"graph"` | the application, which may start a new turn on it |
+| `data-event="<name>"` | none | let the backend decide (the original form, unchanged) |
+
+Only the most specific attribute on an element is used, in the order above; an
+empty value is not a trigger. Backends that don't model routing ignore `scope`, so
+`data-event` keeps behaving exactly as it did.
+
+- `data-payload='<json>'` → parsed and sent as the payload; invalid JSON is sent as the raw string.
+- `<form component-event="...">` (or `mekik-event` / `data-event`) → the submit is intercepted and the named fields are sent, merged over `data-payload`.
+
+The frame that reaches the backend also carries `component` — the registry name of
+the widget the interaction came from. `GenUIMessage` fills that in from the chunk,
+so a component never sets it itself.
+
+### Safety
+
+Markup is sanitized by default: `<script>`, `<iframe>`, `<object>`, `<link>`, `<meta>` and friends are dropped, every `on*` attribute is stripped, and absolute URLs must use a trusted scheme (`http(s):`, `mailto:`, `tel:`, `sms:`, `ftp:`, or `data:image/`) — relative URLs pass through untouched, and obfuscated variants (embedded tabs or newlines, mixed case) are normalised before the check. Structure, classes and inline styles survive untouched. The sanitizer is exported as `sanitizeHtml(markup)` if you want to run it earlier in your pipeline.
+
+Setting `unsafe` re-enables `<script>` and inline handlers — only do that for markup you generate yourself, never for text an LLM or an end user can influence.
+
+### Outside a chat message
+
+`<chativa-html>` is a plain custom element, so it works anywhere:
+
+```html
+<!-- Markup as children -->
+<chativa-html>
+  <button data-event="say_hi">Hi</button>
+</chativa-html>
+```
+
+```tsx
+// React
+<chativa-html ref={(el) => { if (el) el.html = markup; }} />
+```
+
+When no host has injected `sendEvent` — i.e. the element isn't inside a `GenUIMessage` — events are dispatched as a bubbling, composed `genui-component-event` DOM event with `detail: { eventType, payload }`, so the page can still react.
+
+## 3. Let the backend define the component (mekik)
+
+The two options above still need the markup to reach the page somehow. A mekik
+backend can skip that: it defines the component itself and announces the catalog
+on connect, so a `{ type: "ui", component: "order-card" }` chunk mounts a widget
+nobody compiled into the client.
+
+```ts
+// mekik server
+const orderCard = defineComponent({
+  name: "order-card",
+  template: `<h3>{{title}}</h3>
+    {{#each lines}}<p>{{this.label}} — {{this.price}} ₺</p>{{/each}}
+    <button mekik-event="track_order" data-payload='{"id":"{{id}}"}'>Track</button>`,
+  css: `h3 { margin: 0 0 8px; }`,
+  props: { id: "", title: "", lines: [] },
+});
+
+const app = mekik({ graph, components: [orderCard] });
+```
+
+Nothing to do on the client: `@chativa/genui` subscribes to the catalog at import
+time, turns each definition into a custom element (via `defineGenUIComponent`) and
+registers it under its name.
+
+### What travels, and when
+
+```
+hello  { componentsHash?: "<cached>" }        ← the widget already sends this frame
+welcome
+genui_components  { hash, components: [...] }  ← only when the hash moved
+                  { hash, unchanged: true }    ← otherwise: no markup
+```
+
+The catalog is cached in `localStorage` under the server URL, so a returning user's
+widgets render before the server answers, and validating the cache costs no extra
+round trip — the hash rides along on the `hello` frame the connector already sends.
+Change a template on the server and the hash changes; the next connect picks it up.
+
+### Template language
+
+| form | meaning |
+|---|---|
+| `{{path.to.value}}` | HTML-escaped interpolation |
+| `{{#if path}} … {{else}} … {{/if}}` | truthiness (empty string / empty array / 0 are false) |
+| `{{#each path}} … {{/each}}` | iteration, with `{{this}}`, `{{this.field}}`, `{{@index}}`, parent scope still visible |
+
+Interactions use the same event-attribute contract as `<chativa-html>`, and arrive
+at the connector as `receiveComponentEvent` — a server-defined component gets the
+same round trip a compiled one does.
+
+With a mekik backend the choice of attribute is what routes the click: a
+`mekik-event` reaches the app's `onGenUiEvent` handler and can start a new turn,
+while a `component-event` reaches only a graph node parked on `mekik.onEvent`
+waiting for that name — so a widget can answer the very run that mounted it. A
+pause waiting that way announces `data.event` on its `interrupt` frame, and the
+connector renders no chat chips for it: the widget on screen is the answer.
+
+### Driving a server-defined component
+
+A definition is markup; what makes it feel alive is the chunk stream. Two moves
+cover almost everything:
+
+**Re-render it.** Send the same `id` again with new props and the element updates
+in place — see [Updating a component in place](./streaming.md#updating-a-component-in-place).
+
+```ts
+// mekik server — one card, walked through its states
+await phase(ctx, "packing",    () => orderCard(ctx, props("Preparing"),  { id: "card-1" }));
+await phase(ctx, "in_transit", () => orderCard(ctx, props("In transit"), { id: "card-1" }));
+```
+
+**Let a human change it.** The run can pause on chips while the widget stays on
+screen, and the answer re-renders that same element:
+
+```ts
+const choice = await mekik.choose(ctx, "What should the courier do?", [
+    mekik.action("Hand it to me", "handover"),
+    mekik.action("Reschedule", "reschedule"),
+] as const);
+
+orderCard(ctx, props(choice === "handover" ? "Delivered" : "Rescheduled"), { id: "card-1" });
+```
+
+Two things to get right on the server side:
+
+- **Pace the updates.** Emissions that land together are invisible; the client
+  renders the final state and nothing looks like it moved.
+- **Wrap pre-pause emissions in `ctx.step`** (`ctx.StepAsync` in .NET) and use
+  literal chunk ids. A resume replays the node from the top: without the journal
+  the whole sequence is re-sent and the widget flashes back through states the
+  user already saw; with it, only what follows the answer travels.
+
+Runnable end to end: [`ts/examples/server-components.ts`](https://github.com/AimTune/mekik/blob/main/ts/examples/server-components.ts)
+and `dotnet/examples/Mekik.ServerComponents` in the mekik repo.
+
+### Limits
+
+### Name collisions
+
+A server definition never silently replaces a component the page already
+registered — a backend must not be able to redefine `genui-form`, or your own
+checkout widget, under your feet. The collision is logged and the local
+component stays.
+
+That default has a sharp edge worth knowing: the local component then renders
+with the *server's* props, which it was never written for, so the widget usually
+comes out blank. If a server-defined widget renders empty, check the console for
+the collision warning first.
+
+Two ways out:
+
+```ts
+import { setServerComponentPolicy } from "@chativa/genui";
+
+// the server is the source of truth for widgets
+setServerComponentPolicy("server-wins");
+```
+
+…or rename one of the two so both can coexist. A definition always replaces an
+earlier definition of the same name *from the server itself* — that is a new
+version of the same widget, not a collision.
+
+### Other limits
+
+- `unsafe` is not honoured from the wire. Server markup is always sanitized.
+- Only `@chativa/connector-mekik` implements the catalog handshake. Other
+  connectors ignore the frame.
+
+## Backend-driven components end to end
+
+With a streaming connector (Mekik, SSE, WebSocket, SignalR), the backend owns the whole widget:
+
+```
+backend frame  { type: "genui", streamId, chunk: { type: "ui", component: "html", props: { html, css } }, done }
+      ↓ connector.onGenUIChunk
+GenUIMessage mounts <chativa-html> and syncs props on every chunk
+      ↓ user clicks [component-event | mekik-event | data-event]
+connector.receiveComponentEvent(streamId, eventType, payload, { scope, component })
+      ↓ e.g. Mekik sends { type: "genui_event", streamId, eventType, scope, component, payload }
+backend
+```
+
+Because props are re-assigned on every chunk, re-sending the same chunk id with new `html` updates the widget in place — that's how you stream a form into its own success state.
 
 ## The injected API
 
-`GenUIMessage` injects four methods at mount time:
+`GenUIMessage` assigns four methods onto each mounted instance, shadowing `GenUIElement`'s defaults:
 
 | Method | Purpose |
 |---|---|
-| `sendEvent(type, payload)` | Send to the connector via `IConnector.receiveComponentEvent`. |
+| `sendEvent(type, payload, opts?)` | Send to the connector via `IConnector.receiveComponentEvent`. `opts` is routing metadata — `{ scope }` says who the interaction is addressed to (see the table above); `component` is stamped in by `GenUIMessage`, never by the component. |
 | `listenEvent(type, cb)` | Subscribe to event chunks targeting this component (`for === this.id`) or broadcast events. |
 | `tFn(key, fallback?)` | i18next translation. |
 | `onLangChange(cb)` | Subscribe to locale changes. Returns an unsubscribe function. |
+
+Outside a message the defaults keep working: `sendEvent` dispatches `genui-component-event`, `listenEvent` registers locally (deliver with `receiveEvent(type, payload)` in tests), and `tFn` / `onLangChange` use the shared i18next instance.
 
 ## Naming convention
 
 - Built-in components are namespaced `genui-<thing>` (kebab-case). For your own widgets, any unique custom-element-compatible name works; just stay consistent across registrations.
 - Don't expose a `translate` property on your component — `HTMLElement.translate` collides. Always use `tFn`.
-
-## Don't extend ChatbotMixin
-
-GenUI components are standalone — they don't share the chat widget's mixin chain. They get the i18n hook via the `tFn` injection, not via `I18nMixin`.
 
 ## See also
 

--- a/docs/genui/streaming.md
+++ b/docs/genui/streaming.md
@@ -16,8 +16,68 @@ Schema: [`schemas/genui/ai-chunk.schema.json`](../../schemas/genui/ai-chunk.sche
 | Chunk | Behaviour |
 |---|---|
 | `text` | Appends a Markdown line. Useful for "intro text" before a component. |
-| `ui` | Mounts a registered component. `component` is the name in `GenUIRegistry`. `id` becomes the component's identity within this stream. |
+| `ui` | Mounts a registered component. `component` is the name in `GenUIRegistry`. `id` becomes the component's identity within this stream — re-send the same id to [update it in place](#updating-a-component-in-place). |
 | `event` | Sent by the bot to update an already-mounted component. If `for` is set, only the component with that `id` receives it. Otherwise it's broadcast to all listeners in the message bubble. |
+
+## Updating a component in place
+
+`id` is the component's identity within the stream, and re-sending a `ui` chunk
+under an id already on screen **replaces** it — same element, new props. That is
+how a progress bar advances, a form flips to its success state, or an order card
+moves from *Preparing* to *Delivered* without stacking three cards in the bubble.
+
+```ts
+// one element, three renders
+onChunk({ type: "ui", component: "order-card", id: "card-1", props: { status: "Preparing" } });
+onChunk({ type: "ui", component: "order-card", id: "card-1", props: { status: "In transit" } });
+onChunk({ type: "ui", component: "order-card", id: "card-1", props: { status: "Delivered" } });
+```
+
+What the client does with that:
+
+1. **ChatEngine** merges the chunk into the message's chunk list. A `ui` chunk
+   whose id is already there overwrites that entry *in position*; a new id is
+   appended. Event chunks always append — they are a log, not a thing on screen.
+2. **GenUIMessage** keeps one element instance per chunk id and assigns the
+   latest props to it, so the DOM node survives the update: focus, scroll
+   position and internal component state stay put. Only what changed re-renders.
+3. If an id is reused for a *different* `component`, the element is rebuilt at
+   the same position rather than having another component's props assigned onto
+   it.
+
+### Two elements, interleaved
+
+Ids are per stream, so distinct elements update independently and keep their
+order of first appearance:
+
+```
+ui card-1  { status: "Preparing" }        → card mounted
+ui card-1  { status: "In transit" }       → card updated
+ui strip-1 { step: "Picked up" }          → strip mounted below it
+ui strip-1 { step: "Out for delivery" }   → strip updated
+```
+
+Result: two elements, four renders. Not four elements.
+
+### Pace it, or you won't see it
+
+An update that arrives in the same millisecond as the mount is invisible — the
+element simply appears in its final state. If you are demoing or debugging an
+in-place update, put a real delay between the emissions on the server; the
+client has no animation of its own to slow it down.
+
+### Ids and pauses
+
+If your backend pauses mid-turn for a human (mekik's interrupts), keep two things
+in mind:
+
+- **Mounted components outlive the pause.** They stay on screen while the chips
+  render, and the answer can update them — an approval that edits a widget
+  already in the transcript.
+- **Use explicit, stable ids across the pause.** A resume replays the node, so an
+  id minted from a counter can drift; a literal like `"card-1"` cannot. In mekik,
+  wrap the pre-pause emissions in `ctx.step` so the replay doesn't re-send states
+  the user already watched.
 
 ## Emitting chunks from a connector
 

--- a/packages/connector-http/src/HttpConnector.ts
+++ b/packages/connector-http/src/HttpConnector.ts
@@ -8,6 +8,7 @@ import type {
   SurveyPayload,
   ToolCallHandler,
   GenUIChunkHandler,
+  GenUIEventOptions,
 } from "@chativa/core";
 import type { OutgoingMessage } from "@chativa/core";
 // Value import — deliberately from the `frames` subpath, not the package root:
@@ -145,12 +146,17 @@ export class HttpConnector implements IConnector {
    * by POSTing the `genui_event` frame to `{url}/messages` — the outbound
    * counterpart of the inbound `genui` frame.
    */
-  receiveComponentEvent(streamId: string, eventType: string, payload: unknown): void {
+  receiveComponentEvent(
+    streamId: string,
+    eventType: string,
+    payload: unknown,
+    opts?: GenUIEventOptions,
+  ): void {
     // Fire-and-forget: a UI event must not block on the POST, and a failed send
     // is not worth tearing the conversation down over.
     void this._fetch(`${this.options.url}/messages`, {
       method: "POST",
-      body: JSON.stringify(createGenUIEventFrame(streamId, eventType, payload)),
+      body: JSON.stringify(createGenUIEventFrame(streamId, eventType, payload, opts)),
     }).catch(() => {});
   }
 
@@ -168,6 +174,11 @@ export class HttpConnector implements IConnector {
         return true;
       case "genui":
         this.genUIChunkHandler?.(frame.streamId, frame.chunk, frame.done);
+        return true;
+      case "genui_components":
+        // Server-defined component catalogs are a mekik feature
+        // (PROTOCOL.md §10). Swallow the frame rather than letting it fall
+        // through and render as a chat bubble.
         return true;
       case "typing":
         this.typingHandler?.(frame.isTyping);

--- a/packages/connector-mekik/src/__tests__/MekikConnector.test.ts
+++ b/packages/connector-mekik/src/__tests__/MekikConnector.test.ts
@@ -325,6 +325,31 @@ describe("MekikConnector socket lifecycle", () => {
       eventType: "form_submit",
       payload: { answer: 42 },
     });
+    // No routing metadata declared → the frame is exactly what it always was.
+    expect(frame.scope).toBeUndefined();
+    expect(frame.component).toBeUndefined();
+  });
+
+  it("puts the interaction's scope and component on the genui_event frame", async () => {
+    const connector = new MekikConnector({ url: "ws://test", reconnect: false });
+    const p = connector.connect();
+    const ws = MockWebSocket.instances[0];
+    ws.open();
+    await p;
+
+    connector.receiveComponentEvent("s1", "rate_delivery", { stars: 5 }, {
+      scope: "component",
+      component: "delivery-card",
+    });
+
+    expect(JSON.parse(ws.sent[ws.sent.length - 1])).toMatchObject({
+      type: "genui_event",
+      streamId: "s1",
+      eventType: "rate_delivery",
+      scope: "component",
+      component: "delivery-card",
+      payload: { stars: 5 },
+    });
   });
 
   it("sends a static token in the hello handshake", async () => {
@@ -682,6 +707,29 @@ describe("MekikConnector mekik/2 human-in-the-loop", () => {
     });
   });
 
+  it("renders nothing for a pause that is waiting on a component event", () => {
+    const { messages, route } = makeConnector();
+    route({
+      type: "interrupt",
+      seq: 6,
+      id: "wait:event:rate_delivery",
+      // No `actions`, no `ui` — but `event` says a widget already on screen
+      // answers this one, so default Approve/Cancel chips would be a dead end.
+      data: { payload: {}, event: "rate_delivery" },
+    });
+
+    expect(messages).toEqual([]);
+  });
+
+  it("still shows default chips for a pause with no actions, ui or event", () => {
+    const { messages, route } = makeConnector();
+    route({ type: "interrupt", seq: 6, id: "gate:interrupt#0", data: { payload: { title: "Proceed?" } } });
+
+    expect(messages).toHaveLength(1);
+    const data = messages[0].data as Record<string, unknown>;
+    expect((data.actions as Array<{ label: string }>).map((a) => a.label)).toEqual(["Approve", "Cancel"]);
+  });
+
   it("stops treating messages as resumes once interrupt_resolved arrives", () => {
     const { connector, route } = makeConnector();
     route({ type: "interrupt", id: "x:interrupt#0", data: { actions: [{ label: "OK", value: true }] } });
@@ -709,5 +757,114 @@ describe("MekikConnector mekik/2 human-in-the-loop", () => {
     expect(messages).toHaveLength(1);
     expect(messages[0].type).toBe("quick-reply");
     expect((messages[0].data as Record<string, unknown>).text).toBe("Still pending?");
+  });
+});
+
+describe("MekikConnector server-defined components", () => {
+  const CARD = { name: "order-card", template: "<p>{{title}}</p>", props: { title: "" } };
+  const key = "chativa:genui-components:ws://test";
+
+  /** In-memory localStorage — the cache reads it through globalThis. */
+  function stubStorage(seed?: Record<string, string>) {
+    const map = new Map<string, string>(Object.entries(seed ?? {}));
+    vi.stubGlobal("localStorage", {
+      getItem: (k: string) => map.get(k) ?? null,
+      setItem: (k: string, v: string) => { map.set(k, v); },
+      removeItem: (k: string) => { map.delete(k); },
+    });
+    return map;
+  }
+
+  beforeEach(() => {
+    MockWebSocket.instances = [];
+    vi.stubGlobal("WebSocket", MockWebSocket);
+  });
+
+  afterEach(() => vi.unstubAllGlobals());
+
+  it("registers a catalog frame and caches it under its hash", () => {
+    const map = stubStorage();
+    const { connector, route } = makeConnector();
+    const seen: unknown[] = [];
+    connector.onGenUIComponents((defs) => seen.push(defs));
+
+    route({ type: "genui_components", hash: "h1", components: [CARD] });
+
+    expect(seen).toEqual([[CARD]]);
+    expect(JSON.parse(map.get(key)!)).toEqual({ hash: "h1", components: [CARD] });
+  });
+
+  it("replays the catalog to a handler that registers late", () => {
+    stubStorage();
+    const { connector, route } = makeConnector();
+    route({ type: "genui_components", hash: "h1", components: [CARD] });
+
+    const seen: unknown[] = [];
+    connector.onGenUIComponents((defs) => seen.push(defs));
+
+    expect(seen).toEqual([[CARD]]);
+  });
+
+  it("ignores an unchanged frame — the cached catalog stands", () => {
+    const map = stubStorage({ [key]: JSON.stringify({ hash: "h1", components: [CARD] }) });
+    const { connector, route } = makeConnector();
+    const seen: unknown[] = [];
+    connector.onGenUIComponents((defs) => seen.push(defs));
+
+    route({ type: "genui_components", hash: "h1", unchanged: true });
+
+    expect(seen).toEqual([]);
+    expect(JSON.parse(map.get(key)!).hash).toBe("h1");
+  });
+
+  it("never renders a catalog frame as a chat bubble", () => {
+    stubStorage();
+    const { messages, route } = makeConnector();
+    route({ type: "genui_components", hash: "h1", components: [CARD] });
+    expect(messages).toHaveLength(0);
+  });
+
+  it("sends the cached hash in hello and publishes the cache before the server answers", async () => {
+    stubStorage({ [key]: JSON.stringify({ hash: "h1", components: [CARD] }) });
+    const connector = new MekikConnector({ url: "ws://test", reconnect: false });
+    const seen: unknown[] = [];
+    connector.onGenUIComponents((defs) => seen.push(defs));
+
+    const p = connector.connect();
+    MockWebSocket.instances[0].open();
+    await p;
+
+    const hello = JSON.parse(MockWebSocket.instances[0].sent[0]);
+    expect(hello.type).toBe("hello");
+    expect(hello.componentsHash).toBe("h1");
+    // Cached widgets render without waiting for the server.
+    expect(seen).toEqual([[CARD]]);
+  });
+
+  it("omits componentsHash when nothing is cached", async () => {
+    stubStorage();
+    const connector = new MekikConnector({ url: "ws://test", reconnect: false });
+
+    const p = connector.connect();
+    MockWebSocket.instances[0].open();
+    await p;
+
+    const hello = JSON.parse(MockWebSocket.instances[0].sent[0]);
+    expect(hello.componentsHash).toBeUndefined();
+  });
+
+  it("replaces the cache when the server ships a new hash", () => {
+    const map = stubStorage({ [key]: JSON.stringify({ hash: "h1", components: [CARD] }) });
+    const { connector, route } = makeConnector();
+    const seen: unknown[][] = [];
+    connector.onGenUIComponents((defs) => seen.push(defs as unknown[]));
+
+    const v2 = { ...CARD, version: "2", template: "<h3>{{title}}</h3>" };
+    route({ type: "genui_components", hash: "h2", components: [v2] });
+
+    const stored = JSON.parse(map.get(key)!);
+    expect(stored.hash).toBe("h2");
+    expect(stored.components[0].template).toBe("<h3>{{title}}</h3>");
+    expect(seen[seen.length - 1]).toEqual([v2]);
   });
 });

--- a/packages/connector-mekik/src/index.ts
+++ b/packages/connector-mekik/src/index.ts
@@ -7,11 +7,15 @@ import type {
   SurveyPayload,
   ToolCallHandler,
   GenUIChunkHandler,
+  GenUIComponentsHandler,
+  GenUIComponentDefinition,
+  GenUIEventOptions,
 } from "@chativa/core";
 import type { OutgoingMessage, MessageAction } from "@chativa/core";
 // Value import — deliberately from the `frames` subpath, not the package root:
 // the root would inline all of core into this connector's standalone bundle.
-import { parseChatFrame, createGenUIEventFrame } from "@chativa/core/frames";
+import { parseChatFrame, createGenUIEventFrame, createGenUIComponentCache } from "@chativa/core/frames";
+import type { GenUIComponentCache } from "@chativa/core/frames";
 import type {
   MekikAuthContext,
   MekikAuthDecision,
@@ -139,8 +143,11 @@ interface PersistedSession {
  *   indicator (`started` → typing on, `finished` → typing off).
  * - `{ type: "genui", streamId, chunk, done }` → Generative UI chunk; mounts a
  *   GenUIRegistry component inline via `onGenUIChunk`.
- * - `{ type: "genui_event", streamId, eventType, payload }` ← sent by us when
- *   a mounted GenUI component fires an event (form submit, card action, …).
+ * - `{ type: "genui_event", streamId, eventType, scope?, component?, payload }` ←
+ *   sent by us when a mounted GenUI component fires an event (form submit, card
+ *   action, …). `scope` says who it is addressed to (§10.4): `"component"` from a
+ *   `component-event` attribute, `"graph"` from `mekik-event`, absent from a plain
+ *   `data-event`.
  * - `{ type: "error", data: { code, message } }` → auth rejection (§2.1),
  *   followed by a close (code 4401); surfaced via `onAuthError`, reconnect off.
  *
@@ -176,6 +183,24 @@ export class MekikConnector implements IConnector {
   private typingHandler: TypingHandler | null = null;
   private toolCallHandler: ToolCallHandler | null = null;
   private genUIChunkHandler: GenUIChunkHandler | null = null;
+  private genUIComponentsHandler: GenUIComponentsHandler | null = null;
+  /**
+   * Components the server announced on this connection. Replayed to a handler
+   * that registers after the frame arrived, and re-sent by the server on every
+   * reconnect (the client de-duplicates by name+version).
+   */
+  private serverComponents: GenUIComponentDefinition[] = [];
+  /**
+   * Catalog cache, keyed by server URL. Lets the handshake carry the stored
+   * hash so an unchanged catalog is never re-sent (PROTOCOL.md §10). Built on
+   * first use — `options` is only assigned in the constructor.
+   */
+  private _componentCache: GenUIComponentCache | null = null;
+
+  private get componentCache(): GenUIComponentCache {
+    this._componentCache ??= createGenUIComponentCache({ namespace: this.options.url });
+    return this._componentCache;
+  }
 
   private reconnectAttempts = 0;
   private reconnectTimer: ReturnType<typeof setTimeout> | null = null;
@@ -411,6 +436,9 @@ export class MekikConnector implements IConnector {
     const d = (frame.data ?? {}) as Record<string, unknown>;
     const payload = (d.payload ?? {}) as Record<string, unknown>;
     const actions = Array.isArray(d.actions) ? (d.actions as MessageAction[]) : undefined;
+    // `event` means the server is parked on `onEvent` (§10.4): a widget already on
+    // screen answers this pause, so there is nothing for the chat to render.
+    const awaitedEvent = typeof d.event === "string" ? d.event : undefined;
     this.openInterrupts.set(id, { ui: d.ui, actions });
     this.typingHandler?.(false);
 
@@ -424,6 +452,10 @@ export class MekikConnector implements IConnector {
       this.genUIChunkHandler?.(`interrupt-${id}`, { type: "ui", component: d.ui.component, props, id: 1 }, true);
       return;
     }
+    // A pause waiting for a component interaction is answered by that component,
+    // not by the chat. Default chips here would be a dead end — tapping "Approve"
+    // sends a `resume` the node is not waiting for.
+    if (awaitedEvent) return;
     // Nothing to answer with: default Approve/Cancel chips.
     this.renderQuickReply(id, interruptText(payload), [{ label: "Approve" }, { label: "Cancel" }]);
   }
@@ -466,13 +498,34 @@ export class MekikConnector implements IConnector {
   }
 
   /**
-   * Forward a GenUI component event (form submit, card action, …) to the
-   * server as `{ type: "genui_event", streamId, eventType, payload }` —
-   * the outbound counterpart of the inbound `genui` frame.
+   * Components the server defines itself (PROTOCOL.md §10). The catalog arrives
+   * right after `welcome`, which can be before the app registers this handler —
+   * so whatever already arrived is replayed immediately.
    */
-  receiveComponentEvent(streamId: string, eventType: string, payload: unknown): void {
+  onGenUIComponents(callback: GenUIComponentsHandler): void {
+    this.genUIComponentsHandler = callback;
+    if (this.serverComponents.length > 0) callback([...this.serverComponents]);
+  }
+
+  /**
+   * Forward a GenUI component event (form submit, card action, …) to the server
+   * as `{ type: "genui_event", streamId, eventType, scope?, component?, payload }`
+   * — the outbound counterpart of the inbound `genui` frame.
+   *
+   * `scope` is what makes the interaction routable server-side (PROTOCOL.md
+   * §10.4): `"component"` (from a `component-event` attribute) reaches only a node
+   * parked waiting for that event name, `"graph"` (from `mekik-event`) reaches the
+   * app's handler, and an absent scope lets the server try both. A `submit` naming
+   * an open interrupt still answers it whatever the scope says.
+   */
+  receiveComponentEvent(
+    streamId: string,
+    eventType: string,
+    payload: unknown,
+    opts?: GenUIEventOptions,
+  ): void {
     void this.sendOrQueue(
-      JSON.stringify(createGenUIEventFrame(streamId, eventType, payload)),
+      JSON.stringify(createGenUIEventFrame(streamId, eventType, payload, opts)),
     );
   }
 
@@ -598,6 +651,14 @@ export class MekikConnector implements IConnector {
       case "genui":
         this.genUIChunkHandler?.(frame.streamId, frame.chunk, frame.done);
         return;
+      case "genui_components":
+        // `unchanged` means our cached catalog is still current — it was
+        // already published when the socket opened, so there is nothing to do.
+        if (frame.unchanged) return;
+        this.serverComponents = frame.definitions;
+        if (frame.hash) this.componentCache.save(frame.hash, frame.definitions);
+        this.genUIComponentsHandler?.(frame.definitions);
+        return;
       case "typing":
         this.typingHandler?.(frame.isTyping);
         return;
@@ -613,7 +674,11 @@ export class MekikConnector implements IConnector {
     // A malformed `tool_call`/`genui` frame is dropped rather than falling
     // through to the message handler: rendering half a trace as a chat bubble
     // would be worse than ignoring a frame the server got wrong.
-    if (data?.type === "tool_call" || data?.type === "genui") return;
+    if (
+      data?.type === "tool_call" ||
+      data?.type === "genui" ||
+      data?.type === "genui_components"
+    ) return;
 
     // A bot message ends any visible "working" state.
     this.typingHandler?.(false);
@@ -710,6 +775,14 @@ export class MekikConnector implements IConnector {
   /** Send the mekik/1 hello handshake once the socket is open, then resolve connect(). */
   private sendHello(ws: WebSocket, token: string | undefined, resolve: () => void): void {
     this.reconnectAttempts = 0;
+    // A returning user's widgets render from cache immediately; the server
+    // only sends markup back when the hash moved on.
+    const cached = this.componentCache.load();
+    const componentsHash = cached?.hash;
+    if (cached && cached.components.length > 0) {
+      this.serverComponents = cached.components;
+      this.genUIComponentsHandler?.([...cached.components]);
+    }
     // mekik/1 handshake — all fields optional, server fills the gaps.
     // `token` is only present when the server authenticates (§2.1).
     ws.send(
@@ -718,6 +791,9 @@ export class MekikConnector implements IConnector {
         userId: this.options.userId,
         conversationId: this.options.conversationId,
         watermark: this.watermark,
+        // ETag for the server-defined component catalog: same hash → the
+        // server answers `unchanged` instead of re-sending the markup.
+        ...(componentsHash ? { componentsHash } : {}),
         ...(token ? { token } : {}),
       }),
     );

--- a/packages/connector-signalr/src/SignalRConnector.ts
+++ b/packages/connector-signalr/src/SignalRConnector.ts
@@ -8,6 +8,7 @@ import type {
   SurveyPayload,
   ToolCallHandler,
   GenUIChunkHandler,
+  GenUIEventOptions,
 } from "@chativa/core";
 import type { OutgoingMessage } from "@chativa/core";
 // Value import — deliberately from the `frames` subpath, not the package root:
@@ -156,11 +157,16 @@ export class SignalRConnector implements IConnector {
    * invoking `genUIEventMethod` with the `genui_event` frame — the outbound
    * counterpart of the inbound `genui` frame.
    */
-  receiveComponentEvent(streamId: string, eventType: string, payload: unknown): void {
+  receiveComponentEvent(
+    streamId: string,
+    eventType: string,
+    payload: unknown,
+    opts?: GenUIEventOptions,
+  ): void {
     // Fire-and-forget: the UI event must not block on the hub round-trip, and
     // a failed send is not worth tearing the conversation down over.
     void this.connection
-      ?.invoke(this.options.genUIEventMethod, createGenUIEventFrame(streamId, eventType, payload))
+      ?.invoke(this.options.genUIEventMethod, createGenUIEventFrame(streamId, eventType, payload, opts))
       .catch(() => {});
   }
 
@@ -176,6 +182,11 @@ export class SignalRConnector implements IConnector {
         return true;
       case "genui":
         this.genUIChunkHandler?.(frame.streamId, frame.chunk, frame.done);
+        return true;
+      case "genui_components":
+        // Server-defined component catalogs are a mekik feature
+        // (PROTOCOL.md §10). Swallow the frame rather than letting it fall
+        // through and render as a chat bubble.
         return true;
       case "typing":
         this.typingHandler?.(frame.isTyping);

--- a/packages/connector-sse/src/SseConnector.ts
+++ b/packages/connector-sse/src/SseConnector.ts
@@ -8,6 +8,7 @@ import type {
   SurveyPayload,
   ToolCallHandler,
   GenUIChunkHandler,
+  GenUIEventOptions,
 } from "@chativa/core";
 import type { OutgoingMessage } from "@chativa/core";
 // Value import — deliberately from the `frames` subpath, not the package root:
@@ -230,13 +231,18 @@ export class SseConnector implements IConnector {
    * by POSTing the `genui_event` frame to `sendUrl` — the outbound counterpart
    * of the inbound `genui` frame, since an SSE stream is receive-only.
    */
-  receiveComponentEvent(streamId: string, eventType: string, payload: unknown): void {
+  receiveComponentEvent(
+    streamId: string,
+    eventType: string,
+    payload: unknown,
+    opts?: GenUIEventOptions,
+  ): void {
     // Fire-and-forget: a UI event must not block on the POST, and a failed send
     // is not worth tearing the conversation down over.
     void fetch(this.options.sendUrl, {
       method: "POST",
       headers: { "Content-Type": "application/json", ...this.options.headers },
-      body: JSON.stringify(createGenUIEventFrame(streamId, eventType, payload)),
+      body: JSON.stringify(createGenUIEventFrame(streamId, eventType, payload, opts)),
     }).catch(() => {});
   }
 
@@ -269,6 +275,11 @@ export class SseConnector implements IConnector {
         return true;
       case "genui":
         this.genUIChunkHandler?.(frame.streamId, frame.chunk, frame.done);
+        return true;
+      case "genui_components":
+        // Server-defined component catalogs are a mekik feature
+        // (PROTOCOL.md §10). Swallow the frame rather than letting it fall
+        // through and render as a chat bubble.
         return true;
       case "typing":
         this.typingHandler?.(frame.isTyping);

--- a/packages/connector-websocket/src/WebSocketConnector.ts
+++ b/packages/connector-websocket/src/WebSocketConnector.ts
@@ -8,6 +8,7 @@ import type {
   SurveyPayload,
   ToolCallHandler,
   GenUIChunkHandler,
+  GenUIEventOptions,
 } from "@chativa/core";
 import type { OutgoingMessage } from "@chativa/core";
 // Value import — deliberately from the `frames` subpath, not the package root:
@@ -142,9 +143,14 @@ export class WebSocketConnector implements IConnector {
    * as `{ type: "genui_event", streamId, eventType, payload }` — the outbound
    * counterpart of the inbound `genui` frame.
    */
-  receiveComponentEvent(streamId: string, eventType: string, payload: unknown): void {
+  receiveComponentEvent(
+    streamId: string,
+    eventType: string,
+    payload: unknown,
+    opts?: GenUIEventOptions,
+  ): void {
     if (this.ws?.readyState !== WebSocket.OPEN) return;
-    this.ws.send(JSON.stringify(createGenUIEventFrame(streamId, eventType, payload)));
+    this.ws.send(JSON.stringify(createGenUIEventFrame(streamId, eventType, payload, opts)));
   }
 
   /**
@@ -159,6 +165,11 @@ export class WebSocketConnector implements IConnector {
         return true;
       case "genui":
         this.genUIChunkHandler?.(frame.streamId, frame.chunk, frame.done);
+        return true;
+      case "genui_components":
+        // Server-defined component catalogs are a mekik feature
+        // (PROTOCOL.md §10). Swallow the frame rather than letting it fall
+        // through and render as a chat bubble.
         return true;
       case "typing":
         this.typingHandler?.(frame.isTyping);

--- a/packages/core/src/application/ChatEngine.ts
+++ b/packages/core/src/application/ChatEngine.ts
@@ -1,13 +1,19 @@
 import type { IConnector, FeedbackType, SurveyPayload } from "../domain/ports/IConnector";
 import type { OutgoingMessage } from "../domain/entities/Message";
 import type { ToolCall } from "../domain/entities/ToolCall";
-import type { AIChunk, AIChunkText, GenUIStreamState } from "../domain/entities/GenUI";
+import type {
+  AIChunk,
+  AIChunkText,
+  GenUIEventOptions,
+  GenUIStreamState,
+} from "../domain/entities/GenUI";
 import { ExtensionRegistry } from "./registries/ExtensionRegistry";
 import { MessageTypeRegistry } from "./registries/MessageTypeRegistry";
 import messageStore from "./stores/MessageStore";
 import chatStore from "./stores/ChatStore";
 import type { ConnectorStatus } from "./stores/ChatStore";
 import { EventBus } from "./EventBus";
+import { genUIDefinitionStore } from "./GenUIDefinitionStore";
 import { createChativaContext } from "./createChativaContext";
 
 export class ChatEngine {
@@ -104,6 +110,17 @@ export class ChatEngine {
 
     this.connector.onGenUIChunk?.((streamId, chunk, done) => {
       this._handleGenUIChunk(streamId, chunk, done);
+    });
+
+    // Server-defined components. The engine only forwards them — turning a
+    // definition into a custom element is `@chativa/genui`'s job, and it
+    // subscribes to the same store (see GenUIDefinitionStore for why the call
+    // can't be direct).
+    this.connector.onGenUIComponents?.((definitions) => {
+      const fresh = genUIDefinitionStore.publish(definitions);
+      if (fresh.length > 0) {
+        EventBus.emit("genui_components_registered", { definitions: fresh });
+      }
     });
 
     // Tool-call lifecycle events accumulate in the store until the reply
@@ -336,12 +353,35 @@ export class ChatEngine {
       this._rememberHost(streamId, msgId);
       return;
     }
-    // Subsequent ui/event chunk — append to the existing GenUI message.
+    // Subsequent ui/event chunk.
     const current = messageStore.getState().messages.find((m) => m.id === existing);
     const prevState = (current?.data ?? { chunks: [], streamingComplete: false }) as unknown as GenUIStreamState;
     messageStore.getState().updateById(existing, {
-      data: { ...current?.data, chunks: [...prevState.chunks, chunk], streamingComplete: false },
+      data: { ...current?.data, chunks: this._mergeChunk(prevState.chunks, chunk), streamingComplete: false },
     });
+  }
+
+  /**
+   * Place one chunk in the stream's chunk list.
+   *
+   * A `ui` chunk re-sent under an id already in the list **replaces** it — that
+   * is the in-place update a connector means by reusing an id (a progress bar
+   * advancing, a form flipping to its success state). Appending instead would
+   * leave two entries for one element, and since the renderer keys element
+   * instances by chunk id, the same DOM node would be asked to occupy two
+   * positions at once — it can only be in the last one, so the earlier slot
+   * renders empty and the widget appears to vanish.
+   *
+   * Event chunks always append: they are a log of what happened, deduplicated at
+   * dispatch time by the renderer, not a thing on screen.
+   */
+  private _mergeChunk(chunks: AIChunk[], chunk: AIChunk): AIChunk[] {
+    if (chunk.type !== "ui") return [...chunks, chunk];
+    const index = chunks.findIndex((c) => c.type === "ui" && c.id === chunk.id);
+    if (index === -1) return [...chunks, chunk];
+    const next = [...chunks];
+    next[index] = chunk;
+    return next;
   }
 
   /** Close every message the stream opened and drain its tool-call trace. */
@@ -408,11 +448,19 @@ export class ChatEngine {
   /**
    * Called by ChatWidget when a GenUI component fires `sendEvent`.
    * Translates the message id back to the connector's stream id and forwards.
+   *
+   * `opts` carries the interaction's routing metadata — which attribute fired it,
+   * which component it came from — for connectors whose protocol models it.
    */
-  receiveComponentEvent(msgId: string, eventType: string, payload: unknown): void {
+  receiveComponentEvent(
+    msgId: string,
+    eventType: string,
+    payload: unknown,
+    opts?: GenUIEventOptions
+  ): void {
     const streamId = this._msgToStream.get(msgId);
     if (!streamId) return; // stream already complete or unknown
-    this.connector.receiveComponentEvent?.(streamId, eventType, payload);
+    this.connector.receiveComponentEvent?.(streamId, eventType, payload, opts);
   }
 
   async destroy(): Promise<void> {

--- a/packages/core/src/application/EventBus.ts
+++ b/packages/core/src/application/EventBus.ts
@@ -18,6 +18,7 @@ import type { OutgoingMessage, IncomingMessage } from "../domain/entities/Messag
 import type { ToolCall } from "../domain/entities/ToolCall";
 import type { ConnectorStatus } from "./stores/ChatStore";
 import type { SurveyPayload } from "../domain/ports/IConnector";
+import type { GenUIComponentDefinition } from "../domain/entities/GenUI";
 
 // ── Event payload map ──────────────────────────────────────────────────────────
 
@@ -44,6 +45,8 @@ export interface EventBusPayloadMap {
   search_query_changed: { query: string };
   /** User submitted an end-of-conversation survey. */
   survey_submitted: SurveyPayload;
+  /** The server announced GenUI components and they were registered. */
+  genui_components_registered: { definitions: GenUIComponentDefinition[] };
   /** A connector tool call started or changed state (upsert by `id`). */
   tool_call_updated: ToolCall;
 }

--- a/packages/core/src/application/GenUIDefinitionStore.ts
+++ b/packages/core/src/application/GenUIDefinitionStore.ts
@@ -1,0 +1,65 @@
+import type { GenUIComponentDefinition } from "../domain/entities/GenUI";
+
+type Subscriber = (definitions: GenUIComponentDefinition[]) => void;
+
+const _definitions = new Map<string, GenUIComponentDefinition>();
+const _subscribers = new Set<Subscriber>();
+
+const keyOf = (d: GenUIComponentDefinition) => `${d.name}@${d.version ?? "1"}`;
+
+/**
+ * Where server-defined GenUI components land between the connector and the
+ * renderer.
+ *
+ * The layering forbids the direct call: `@chativa/core` must not import
+ * `GenUIRegistry` from `@chativa/genui`, and a connector must not know a
+ * registry exists at all. So the connector publishes definitions here (via
+ * ChatEngine) and `@chativa/genui` subscribes — each side depends only on core.
+ *
+ * Subscribers get an immediate replay of everything already published, because
+ * the connector may well have connected before the GenUI bundle finished
+ * loading.
+ */
+export const genUIDefinitionStore = {
+  /**
+   * Publish a catalog. Definitions already known by `name@version` are dropped,
+   * so a reconnect that re-announces the same catalog notifies nobody.
+   *
+   * @returns the definitions that were actually new.
+   */
+  publish(definitions: GenUIComponentDefinition[]): GenUIComponentDefinition[] {
+    const fresh = definitions.filter(
+      (d) => d && typeof d.name === "string" && d.name && !_definitions.has(keyOf(d))
+    );
+    if (fresh.length === 0) return [];
+    for (const d of fresh) _definitions.set(keyOf(d), d);
+    for (const cb of _subscribers) cb(fresh);
+    return fresh;
+  },
+
+  /**
+   * Subscribe to published definitions; the callback fires once immediately
+   * with everything published so far. Returns an unsubscribe function.
+   */
+  subscribe(cb: Subscriber): () => void {
+    _subscribers.add(cb);
+    const known = Array.from(_definitions.values());
+    if (known.length > 0) cb(known);
+    return () => { _subscribers.delete(cb); };
+  },
+
+  /** Everything published so far. */
+  list(): GenUIComponentDefinition[] {
+    return Array.from(_definitions.values());
+  },
+
+  has(name: string, version?: string): boolean {
+    return _definitions.has(`${name}@${version ?? "1"}`);
+  },
+
+  /** Reset — for use in tests only. */
+  clear(): void {
+    _definitions.clear();
+    _subscribers.clear();
+  },
+};

--- a/packages/core/src/application/__tests__/ChatEngine.test.ts
+++ b/packages/core/src/application/__tests__/ChatEngine.test.ts
@@ -683,7 +683,32 @@ describe("ChatEngine", () => {
     connector.simulateGenUIChunk("stream-ce", { type: "ui", component: "card", props: {}, id: 1 }, false);
     const msgId = messageStore.getState().messages[0].id;
     engine.receiveComponentEvent(msgId, "click", { value: 42 });
-    expect(connector.receiveComponentEvent).toHaveBeenCalledWith("stream-ce", "click", { value: 42 });
+    expect(connector.receiveComponentEvent).toHaveBeenCalledWith(
+      "stream-ce",
+      "click",
+      { value: 42 },
+      undefined,
+    );
+  });
+
+  it("forwards the interaction's routing metadata to the connector", async () => {
+    const connector = createMockConnector();
+    const engine = new ChatEngine(connector);
+    await engine.init();
+    connector.simulateGenUIChunk("stream-ce", { type: "ui", component: "card", props: {}, id: 1 }, false);
+    const msgId = messageStore.getState().messages[0].id;
+
+    engine.receiveComponentEvent(msgId, "rate", { stars: 5 }, {
+      scope: "component",
+      component: "delivery-card",
+    });
+
+    expect(connector.receiveComponentEvent).toHaveBeenCalledWith(
+      "stream-ce",
+      "rate",
+      { stars: 5 },
+      { scope: "component", component: "delivery-card" },
+    );
   });
 
   it("ignores receiveComponentEvent for unknown msgId", async () => {

--- a/packages/core/src/application/__tests__/GenUIChunkMerge.test.ts
+++ b/packages/core/src/application/__tests__/GenUIChunkMerge.test.ts
@@ -1,0 +1,134 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import type { AIChunk, GenUIStreamState } from "../../domain/entities/GenUI";
+import type { IConnector, MessageHandler } from "../../domain/ports/IConnector";
+import type { GenUIChunkHandler } from "../../domain/entities/GenUI";
+import { ChatEngine } from "../ChatEngine";
+import messageStore from "../stores/MessageStore";
+import { MessageTypeRegistry } from "../registries/MessageTypeRegistry";
+
+/**
+ * How a stream's chunks accumulate into one GenUI message.
+ *
+ * The rule under test: a `ui` chunk re-sent under an id already in the list
+ * replaces it. Appending instead put two entries on screen for one element, and
+ * because the renderer keys instances by chunk id, the same DOM node was asked
+ * to occupy both positions — so the earlier one rendered empty and the widget
+ * looked like it had disappeared (or been replaced by the next component).
+ */
+class FakeConnector implements IConnector {
+  readonly name = "fake";
+  private genUI: GenUIChunkHandler | null = null;
+
+  async connect(): Promise<void> {}
+  async disconnect(): Promise<void> {}
+  async sendMessage(): Promise<void> {}
+  onMessage(_cb: MessageHandler): void {}
+  onConnect(): void {}
+  onDisconnect(): void {}
+  onTyping(): void {}
+  onGenUIChunk(cb: GenUIChunkHandler): void {
+    this.genUI = cb;
+  }
+
+  /** Drive one chunk down the same path a real connector uses. */
+  emit(chunk: AIChunk, done = false): void {
+    this.genUI?.("stream-1", chunk, done);
+  }
+}
+
+const ui = (id: string | number, component: string, props: Record<string, unknown>): AIChunk =>
+  ({ type: "ui", component, props, id } as unknown as AIChunk);
+
+/** Props of a `ui` chunk, without a cast at every call site. */
+const propsOf = (chunk: AIChunk | undefined): Record<string, unknown> =>
+  chunk && chunk.type === "ui" ? chunk.props : {};
+
+const componentOf = (chunk: AIChunk | undefined): string | undefined =>
+  chunk && chunk.type === "ui" ? chunk.component : undefined;
+
+const chunksOf = (): AIChunk[] => {
+  const msg = messageStore.getState().messages.find((m) => m.type === "genui");
+  return ((msg?.data as unknown as GenUIStreamState) ?? { chunks: [] }).chunks;
+};
+
+let connector: FakeConnector;
+
+beforeEach(async () => {
+  // The engine resolves a renderer for every message it creates; core tests
+  // register no components, so stand in for the ones @chativa/genui provides.
+  MessageTypeRegistry.register("genui", class extends HTMLElement {} as unknown as never);
+  MessageTypeRegistry.register("text", class extends HTMLElement {} as unknown as never);
+  messageStore.getState().clear();
+  connector = new FakeConnector();
+  await new ChatEngine(connector).init();
+});
+
+describe("GenUI chunk merging", () => {
+  it("keeps one entry per ui chunk id and applies the newest props", () => {
+    connector.emit(ui("card-1", "order-card", { status: "Preparing" }));
+    connector.emit(ui("card-1", "order-card", { status: "In transit" }));
+
+    const chunks = chunksOf();
+    expect(chunks).toHaveLength(1);
+    expect(propsOf(chunks[0]).status).toBe("In transit");
+  });
+
+  it("keeps distinct components side by side while each updates in place", () => {
+    connector.emit(ui("card-1", "order-card", { status: "Preparing" }));
+    connector.emit(ui("card-1", "order-card", { status: "In transit" }));
+    connector.emit(ui("strip-1", "shipment-strip", { step: "Picked up" }));
+    connector.emit(ui("strip-1", "shipment-strip", { step: "Out for delivery" }));
+
+    const chunks = chunksOf();
+    expect(chunks.map(componentOf)).toEqual([
+      "order-card",
+      "shipment-strip",
+    ]);
+    expect(propsOf(chunks[0]).status).toBe("In transit");
+    expect(propsOf(chunks[1]).step).toBe("Out for delivery");
+  });
+
+  it("holds an updated chunk in its original position", () => {
+    connector.emit(ui("a", "genui-alert", { message: "first" }));
+    connector.emit(ui("b", "genui-progress", { value: 10 }));
+    connector.emit(ui("a", "genui-alert", { message: "updated" }));
+
+    const chunks = chunksOf();
+    expect(chunks).toHaveLength(2);
+    expect(propsOf(chunks[0]).message).toBe("updated");
+    expect(componentOf(chunks[1])).toBe("genui-progress");
+  });
+
+  it("updates the component too when an id is reused for a different one", () => {
+    connector.emit(ui("slot", "genui-progress", { value: 10 }));
+    connector.emit(ui("slot", "genui-alert", { message: "done" }));
+
+    const chunks = chunksOf();
+    expect(chunks).toHaveLength(1);
+    expect(componentOf(chunks[0])).toBe("genui-alert");
+  });
+
+  it("appends event chunks rather than collapsing them by id", () => {
+    connector.emit(ui("card-1", "order-card", { status: "Preparing" }));
+    connector.emit({ type: "event", name: "step_done", id: 1 } as AIChunk);
+    connector.emit({ type: "event", name: "step_done", id: 2 } as AIChunk);
+
+    expect(chunksOf().filter((c) => c.type === "event")).toHaveLength(2);
+  });
+
+  it("survives the whole tracker sequence — 6 chunks, 2 elements", () => {
+    // The exact shape of examples/server-components: four pre-pause chunks, then
+    // two more after the human answers the chips.
+    connector.emit(ui("order-card-1", "order-card", { status: "Preparing" }));
+    connector.emit(ui("order-card-1", "order-card", { status: "In transit" }));
+    connector.emit(ui("shipment-strip-1", "shipment-strip", { step: "Picked up" }));
+    connector.emit(ui("shipment-strip-1", "shipment-strip", { step: "Out for delivery" }));
+    connector.emit(ui("order-card-1", "order-card", { status: "Delivered" }));
+    connector.emit(ui("shipment-strip-1", "shipment-strip", { step: "Delivered" }));
+
+    const chunks = chunksOf();
+    expect(chunks).toHaveLength(2);
+    expect(propsOf(chunks[0]).status).toBe("Delivered");
+    expect(propsOf(chunks[1]).step).toBe("Delivered");
+  });
+});

--- a/packages/core/src/application/__tests__/GenUIDefinitionStore.test.ts
+++ b/packages/core/src/application/__tests__/GenUIDefinitionStore.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { GenUIComponentDefinition } from "../../domain/entities/GenUI";
+import { genUIDefinitionStore } from "../GenUIDefinitionStore";
+
+const card: GenUIComponentDefinition = { name: "order-card", template: "<p>{{title}}</p>" };
+const list: GenUIComponentDefinition = { name: "order-list", template: "<ul></ul>" };
+
+beforeEach(() => genUIDefinitionStore.clear());
+
+describe("genUIDefinitionStore", () => {
+  it("notifies subscribers of published definitions", () => {
+    const cb = vi.fn();
+    genUIDefinitionStore.subscribe(cb);
+    genUIDefinitionStore.publish([card]);
+
+    expect(cb).toHaveBeenCalledWith([card]);
+  });
+
+  it("replays what was published before the subscription", () => {
+    genUIDefinitionStore.publish([card]);
+    const cb = vi.fn();
+    genUIDefinitionStore.subscribe(cb);
+
+    expect(cb).toHaveBeenCalledWith([card]);
+  });
+
+  it("drops definitions it already knows, so a reconnect notifies nobody", () => {
+    genUIDefinitionStore.publish([card]);
+    const cb = vi.fn();
+    genUIDefinitionStore.subscribe(cb);
+    cb.mockClear();
+
+    expect(genUIDefinitionStore.publish([card])).toEqual([]);
+    expect(cb).not.toHaveBeenCalled();
+  });
+
+  it("publishes only the new definitions of a partially known catalog", () => {
+    genUIDefinitionStore.publish([card]);
+    const cb = vi.fn();
+    genUIDefinitionStore.subscribe(cb);
+    cb.mockClear();
+
+    expect(genUIDefinitionStore.publish([card, list])).toEqual([list]);
+    expect(cb).toHaveBeenCalledWith([list]);
+  });
+
+  it("treats a new version of the same name as new", () => {
+    genUIDefinitionStore.publish([card]);
+    const v2 = { ...card, version: "2" };
+
+    expect(genUIDefinitionStore.publish([v2])).toEqual([v2]);
+    expect(genUIDefinitionStore.list()).toHaveLength(2);
+  });
+
+  it("ignores definitions without a name", () => {
+    expect(genUIDefinitionStore.publish([{ name: "", template: "x" }])).toEqual([]);
+    expect(genUIDefinitionStore.list()).toEqual([]);
+  });
+
+  it("reports what it knows", () => {
+    genUIDefinitionStore.publish([card]);
+
+    expect(genUIDefinitionStore.has("order-card")).toBe(true);
+    expect(genUIDefinitionStore.has("order-card", "2")).toBe(false);
+    expect(genUIDefinitionStore.has("nope")).toBe(false);
+  });
+
+  it("stops notifying after unsubscribe", () => {
+    const cb = vi.fn();
+    const unsub = genUIDefinitionStore.subscribe(cb);
+    unsub();
+    genUIDefinitionStore.publish([card]);
+
+    expect(cb).not.toHaveBeenCalled();
+  });
+});

--- a/packages/core/src/application/index.ts
+++ b/packages/core/src/application/index.ts
@@ -11,6 +11,7 @@ export { default as conversationStore } from "./stores/ConversationStore";
 export type { ChatStoreState, ConnectorStatus, TypingOptions } from "./stores/ChatStore";
 export type { StoredMessage, MessageStoreState } from "./stores/MessageStore";
 export type { ConversationStoreState } from "./stores/ConversationStore";
+export { genUIDefinitionStore } from "./GenUIDefinitionStore";
 export { EventBus } from "./EventBus";
 export type { EventBusPayloadMap, EventBusEventName } from "./EventBus";
 export type { ChativaContext } from "./ChativaContext";

--- a/packages/core/src/domain/entities/ChatFrame.ts
+++ b/packages/core/src/domain/entities/ChatFrame.ts
@@ -18,7 +18,12 @@
 
 import type { IncomingMessage, MessageAction } from "./Message";
 import type { ToolCall } from "./ToolCall";
-import type { AIChunk } from "./GenUI";
+import type {
+  AIChunk,
+  GenUIComponentDefinition,
+  GenUIEventOptions,
+  GenUIEventScope,
+} from "./GenUI";
 
 /** A wire frame parsed into what the connector should do with it. */
 export type ChatFrame =
@@ -26,6 +31,18 @@ export type ChatFrame =
   | { kind: "tool_call"; toolCall: ToolCall }
   /** One Generative UI chunk of the `streamId` stream. */
   | { kind: "genui"; streamId: string; chunk: AIChunk; done: boolean }
+  /**
+   * The server's catalog of components it defines itself — register them, then
+   * mount by name. `hash` versions the catalog (send it back in the next
+   * handshake); `unchanged` means the client's cached catalog is still current
+   * and `definitions` is empty.
+   */
+  | {
+      kind: "genui_components";
+      definitions: GenUIComponentDefinition[];
+      hash?: string;
+      unchanged: boolean;
+    }
   /** Typing indicator toggle. */
   | { kind: "typing"; isTyping: boolean }
   /** A bot question with chips — the human-in-the-loop interrupt. */
@@ -58,6 +75,7 @@ function isRecord(value: unknown): value is Record<string, unknown> {
  * switch (frame.kind) {
  *   case "tool_call":   return onToolCall(frame.toolCall);
  *   case "genui":       return onGenUIChunk(frame.streamId, frame.chunk, frame.done);
+ *   case "genui_components": return onGenUIComponents(frame.definitions);
  *   case "typing":      return onTyping(frame.isTyping);
  *   case "quick_reply": return onMessage(frame.message);
  *   case "other":       break; // your own handling
@@ -99,6 +117,28 @@ export function parseChatFrame(
     return { kind: "other" };
   }
 
+  // { type: "genui_components", hash?, unchanged?, components: [{ name, template, … }] }
+  // The server defines the component itself; the client registers it and mounts
+  // it by name from then on. `unchanged: true` is the cache hit — the client's
+  // stored catalog matches `hash`, so no markup travels. A definition without a
+  // name or a string template is dropped: a half-formed component would render
+  // as an empty bubble.
+  if (raw.type === "genui_components") {
+    const list = Array.isArray(raw.components) ? raw.components : [];
+    const definitions = list.filter(
+      (d): d is GenUIComponentDefinition =>
+        isRecord(d) && typeof d.name === "string" && !!d.name && typeof d.template === "string"
+    );
+    const unchanged = raw.unchanged === true;
+    if (definitions.length === 0 && !unchanged) return { kind: "other" };
+    return {
+      kind: "genui_components",
+      definitions,
+      unchanged,
+      ...(typeof raw.hash === "string" && raw.hash ? { hash: raw.hash } : {}),
+    };
+  }
+
   // { type: "typing", isTyping: boolean }
   if (raw.type === "typing") {
     return { kind: "typing", isTyping: raw.isTyping === true };
@@ -134,11 +174,31 @@ export function parseChatFrame(
   return { kind: "other" };
 }
 
-/** Build the outbound frame for a GenUI component event (form submit, card action…). */
+/**
+ * Build the outbound frame for a GenUI component event (form submit, card action…).
+ *
+ * `scope` and `component` are omitted when unknown rather than sent as `null`, so a
+ * backend that does not model routing sees exactly the frame it saw before.
+ */
 export function createGenUIEventFrame(
   streamId: string,
   eventType: string,
   payload: unknown,
-): { type: "genui_event"; streamId: string; eventType: string; payload: unknown } {
-  return { type: "genui_event", streamId, eventType, payload };
+  opts?: GenUIEventOptions,
+): {
+  type: "genui_event";
+  streamId: string;
+  eventType: string;
+  payload: unknown;
+  scope?: GenUIEventScope;
+  component?: string;
+} {
+  return {
+    type: "genui_event",
+    streamId,
+    eventType,
+    payload,
+    ...(opts?.scope ? { scope: opts.scope } : {}),
+    ...(opts?.component ? { component: opts.component } : {}),
+  };
 }

--- a/packages/core/src/domain/entities/GenUI.ts
+++ b/packages/core/src/domain/entities/GenUI.ts
@@ -64,3 +64,97 @@ export type GenUIChunkHandler = (
   chunk: AIChunk,
   done: boolean
 ) => void;
+
+/**
+ * A component the *server* defines, shipped to the client so it can be rendered
+ * without any client-side build step.
+ *
+ * The backend author writes the component once (a class in mekik, say), the
+ * server turns it into this metadata, and the connector hands it over on
+ * connect — the client registers it in its GenUI registry and from then on a
+ * plain `{ type: "ui", component: "<name>", props }` chunk mounts it.
+ *
+ * Templates are markup, never code: see `renderTemplate` for the supported
+ * subset (`{{value}}`, `{{#if}}`, `{{#each}}`). Rendered output is sanitized
+ * before it reaches the DOM — a server definition cannot opt out of that.
+ */
+export interface GenUIComponentDefinition {
+  /** Registry name used by `AIChunkUI.component`, e.g. `"order-card"`. */
+  name: string;
+  /** Markup with `{{…}}` placeholders. */
+  template: string;
+  /** Optional CSS, scoped to the component's shadow root. */
+  css?: string;
+  /**
+   * Declared props: name → default value. Drives both the template scope and
+   * the client's reactivity, so a re-sent chunk updates the widget in place.
+   */
+  props?: Record<string, unknown>;
+  /**
+   * Definition version. A changed version re-registers the component instead of
+   * reusing the previously defined class.
+   */
+  version?: string;
+  /** Custom element tag to define. Derived from `name` when omitted. */
+  tag?: string;
+}
+
+/** Callback registered via `IConnector.onGenUIComponents`. */
+export type GenUIComponentsHandler = (
+  definitions: GenUIComponentDefinition[]
+) => void;
+
+/**
+ * Who a component interaction is addressed to, when the backend distinguishes
+ * (mekik `PROTOCOL.md` §10.4).
+ *
+ * - `"component"` — the widget's own conversation with the graph node that
+ *   mounted it: only a node parked waiting for this event name receives it.
+ * - `"graph"` — the application: it may start a new turn on the interaction.
+ *
+ * Omit it and the backend decides; mekik tries the component route first, then
+ * the graph one. Backends that do not model the distinction ignore it.
+ */
+export type GenUIEventScope = "component" | "graph";
+
+/** Optional routing metadata that travels with a component event. */
+export interface GenUIEventOptions {
+  /** See {@link GenUIEventScope}. */
+  scope?: GenUIEventScope;
+  /**
+   * Registry name of the component the interaction came from. `GenUIMessage`
+   * fills this in from the chunk, so components never set it themselves.
+   */
+  component?: string;
+}
+
+/**
+ * API that `GenUIMessage` injects into every mounted GenUI component instance.
+ *
+ * `GenUIElement` implements all four with working defaults, so extending it is
+ * the recommended way to consume this contract — the injection simply shadows
+ * the defaults with message-scoped versions.
+ */
+export interface GenUIComponentAPI {
+  /**
+   * Send an event to the connector (e.g. `"form_submit"`, `"rating_submit"`).
+   *
+   * `opts` is routing metadata for backends that distinguish who an interaction
+   * is for; leave it off and the backend decides. See {@link GenUIEventOptions}.
+   */
+  sendEvent(type: string, payload: unknown, opts?: GenUIEventOptions): void;
+  /** Listen for a server-originated event within this message scope. */
+  listenEvent(type: string, cb: (payload: unknown) => void): void;
+  /**
+   * Translate a key using the shared i18next instance.
+   * Falls back to `fallback` if the key is not found.
+   * Named `tFn` (not `translate`) to avoid conflict with the native
+   * `HTMLElement.translate` boolean attribute.
+   */
+  tFn(key: string, fallback?: string): string;
+  /**
+   * Subscribe to locale changes so you can call `requestUpdate()`.
+   * Returns an unsubscribe function — call it in `disconnectedCallback`.
+   */
+  onLangChange(cb: () => void): () => void;
+}

--- a/packages/core/src/domain/entities/GenUIComponentCache.ts
+++ b/packages/core/src/domain/entities/GenUIComponentCache.ts
@@ -1,0 +1,133 @@
+/**
+ * GenUIComponentCache — the client half of the component-catalog handshake.
+ *
+ * A server-defined catalog is markup, not code, and it rarely changes: re-sending
+ * every component on every reconnect wastes the first frames of every session. So
+ * the catalog is versioned by an opaque hash the *server* mints — an ETag:
+ *
+ * 1. The client stores `{ hash, components }` after the first catalog.
+ * 2. On the next connect it sends the stored hash in the handshake
+ *    (`hello.componentsHash`).
+ * 3. The server compares. Same hash → it answers `{ unchanged: true }` and sends
+ *    no markup; different (or missing) → it sends the full catalog and its hash.
+ *
+ * The client never computes the hash, so the server is free to derive it however
+ * it likes (SHA-256 of the serialized catalog, a build id, a content version).
+ * The client only has to hand back exactly what it was given.
+ *
+ * Cached components are published as soon as the connector connects, so a
+ * returning user's widgets render without waiting for a round trip.
+ *
+ * No external dependencies allowed in this file — storage is injected, and the
+ * default is looked up lazily so this stays importable outside a browser.
+ */
+
+import type { GenUIComponentDefinition } from "./GenUI";
+
+/** The slice of the Web Storage API the cache needs. */
+export interface GenUIComponentCacheStorage {
+  getItem(key: string): string | null;
+  setItem(key: string, value: string): void;
+  removeItem(key: string): void;
+}
+
+/** What one cache entry holds. */
+export interface CachedGenUIComponents {
+  /** The server-minted catalog hash this entry was stored under. */
+  hash: string;
+  components: GenUIComponentDefinition[];
+}
+
+export interface GenUIComponentCacheOptions {
+  /**
+   * Distinguishes catalogs that must not be mixed up — pass the server URL, so
+   * staging and production don't hand each other's markup back.
+   */
+  namespace: string;
+  /** Defaults to `globalThis.localStorage` when available. */
+  storage?: GenUIComponentCacheStorage;
+}
+
+export interface GenUIComponentCache {
+  /** The cached catalog, or null when there is none / it is unreadable. */
+  load(): CachedGenUIComponents | null;
+  /** The cached hash to send in the handshake, or undefined when nothing is cached. */
+  hash(): string | undefined;
+  /** Replace the cached catalog. A falsy hash clears the entry instead. */
+  save(hash: string, components: GenUIComponentDefinition[]): void;
+  /** Drop the entry. */
+  clear(): void;
+}
+
+function defaultStorage(): GenUIComponentCacheStorage | null {
+  try {
+    const ls = (globalThis as { localStorage?: GenUIComponentCacheStorage }).localStorage;
+    return ls ?? null;
+  } catch {
+    // Storage access can throw outright (blocked third-party cookies, some
+    // privacy modes). No cache is a slow path, not a broken one.
+    return null;
+  }
+}
+
+/**
+ * Create a catalog cache.
+ *
+ * Every operation swallows storage errors: a full quota or a blocked origin
+ * costs a round trip, and must never break the connection.
+ *
+ * @example
+ * ```ts
+ * const cache = createGenUIComponentCache({ namespace: options.url });
+ * // on connect
+ * const cached = cache.load();
+ * if (cached) onGenUIComponents(cached.components);
+ * ws.send(JSON.stringify({ type: "hello", componentsHash: cache.hash() }));
+ * // on { type: "genui_components", hash, components }
+ * cache.save(hash, components);
+ * ```
+ */
+export function createGenUIComponentCache(
+  options: GenUIComponentCacheOptions
+): GenUIComponentCache {
+  const key = `chativa:genui-components:${options.namespace}`;
+  const store = () => options.storage ?? defaultStorage();
+
+  const load = (): CachedGenUIComponents | null => {
+    try {
+      const raw = store()?.getItem(key);
+      if (!raw) return null;
+      const parsed = JSON.parse(raw) as Partial<CachedGenUIComponents>;
+      if (typeof parsed?.hash !== "string" || !Array.isArray(parsed.components)) return null;
+      // A stored entry is only as trustworthy as its shape — a half-written or
+      // hand-edited entry must not reach the renderer.
+      const components = parsed.components.filter(
+        (d): d is GenUIComponentDefinition =>
+          !!d && typeof d.name === "string" && typeof d.template === "string"
+      );
+      return { hash: parsed.hash, components };
+    } catch {
+      return null;
+    }
+  };
+
+  return {
+    load,
+    hash: () => load()?.hash,
+    save(hash, components) {
+      try {
+        if (!hash) return this.clear();
+        store()?.setItem(key, JSON.stringify({ hash, components }));
+      } catch {
+        /* quota or blocked storage — the catalog just gets re-sent next time */
+      }
+    },
+    clear() {
+      try {
+        store()?.removeItem(key);
+      } catch {
+        /* ignore */
+      }
+    },
+  };
+}

--- a/packages/core/src/domain/entities/__tests__/GenUIComponentCache.test.ts
+++ b/packages/core/src/domain/entities/__tests__/GenUIComponentCache.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import type { GenUIComponentDefinition } from "../GenUI";
+import {
+  createGenUIComponentCache,
+  type GenUIComponentCacheStorage,
+} from "../GenUIComponentCache";
+
+const DEFS: GenUIComponentDefinition[] = [
+  { name: "order-card", template: "<p>{{title}}</p>", props: { title: "" } },
+];
+
+class MemoryStorage implements GenUIComponentCacheStorage {
+  map = new Map<string, string>();
+  getItem(k: string) { return this.map.get(k) ?? null; }
+  setItem(k: string, v: string) { this.map.set(k, v); }
+  removeItem(k: string) { this.map.delete(k); }
+}
+
+let storage: MemoryStorage;
+const cache = () => createGenUIComponentCache({ namespace: "ws://a.test/chat", storage });
+
+beforeEach(() => { storage = new MemoryStorage(); });
+
+describe("createGenUIComponentCache", () => {
+  it("round-trips a catalog", () => {
+    const c = cache();
+    c.save("h1", DEFS);
+
+    expect(c.hash()).toBe("h1");
+    expect(c.load()?.components).toEqual(DEFS);
+  });
+
+  it("returns null / undefined when nothing is cached", () => {
+    expect(cache().load()).toBeNull();
+    expect(cache().hash()).toBeUndefined();
+  });
+
+  it("keys entries by namespace so two servers don't share markup", () => {
+    createGenUIComponentCache({ namespace: "a", storage }).save("h1", DEFS);
+    expect(createGenUIComponentCache({ namespace: "b", storage }).load()).toBeNull();
+  });
+
+  it("replaces the entry on save", () => {
+    const c = cache();
+    c.save("h1", DEFS);
+    c.save("h2", [{ name: "other", template: "<b>x</b>" }]);
+
+    expect(c.hash()).toBe("h2");
+    expect(c.load()?.components).toHaveLength(1);
+    expect(c.load()?.components[0]!.name).toBe("other");
+  });
+
+  it("clears", () => {
+    const c = cache();
+    c.save("h1", DEFS);
+    c.clear();
+    expect(c.load()).toBeNull();
+  });
+
+  it("treats an empty hash as a clear", () => {
+    const c = cache();
+    c.save("h1", DEFS);
+    c.save("", DEFS);
+    expect(c.load()).toBeNull();
+  });
+
+  it("ignores a corrupted entry instead of throwing", () => {
+    storage.setItem("chativa:genui-components:ws://a.test/chat", "{not json");
+    expect(cache().load()).toBeNull();
+  });
+
+  it("ignores an entry with the wrong shape", () => {
+    storage.setItem("chativa:genui-components:ws://a.test/chat", JSON.stringify({ hash: 1 }));
+    expect(cache().load()).toBeNull();
+  });
+
+  it("drops malformed definitions from a stored catalog", () => {
+    storage.setItem(
+      "chativa:genui-components:ws://a.test/chat",
+      JSON.stringify({ hash: "h1", components: [DEFS[0], { name: "broken" }, null] })
+    );
+    expect(cache().load()?.components).toHaveLength(1);
+  });
+
+  it("survives a storage that throws on write", () => {
+    const hostile: GenUIComponentCacheStorage = {
+      getItem: () => null,
+      setItem: () => { throw new Error("QuotaExceededError"); },
+      removeItem: () => { throw new Error("nope"); },
+    };
+    const c = createGenUIComponentCache({ namespace: "x", storage: hostile });
+
+    expect(() => c.save("h1", DEFS)).not.toThrow();
+    expect(() => c.clear()).not.toThrow();
+    expect(c.load()).toBeNull();
+  });
+});

--- a/packages/core/src/domain/index.ts
+++ b/packages/core/src/domain/index.ts
@@ -1,9 +1,11 @@
 // Domain — pure types and interfaces
 export type { IncomingMessage, OutgoingMessage, MessageSender, MessageAction, MessageStatus, HistoryResult } from "./entities/Message";
-export type { AIChunk, AIChunkText, AIChunkUI, AIChunkEvent, GenUIStreamState, GenUIChunkHandler } from "./entities/GenUI";
+export type { AIChunk, AIChunkText, AIChunkUI, AIChunkEvent, GenUIStreamState, GenUIChunkHandler, GenUIComponentAPI, GenUIComponentDefinition, GenUIComponentsHandler, GenUIEventOptions, GenUIEventScope } from "./entities/GenUI";
 export type { ToolCall, ToolCallStatus, ToolCallHandler } from "./entities/ToolCall";
 export type { ChatFrame, ParseChatFrameOptions } from "./entities/ChatFrame";
 export { parseChatFrame, createGenUIEventFrame } from "./entities/ChatFrame";
+export { createGenUIComponentCache } from "./entities/GenUIComponentCache";
+export type { GenUIComponentCache, GenUIComponentCacheOptions, GenUIComponentCacheStorage, CachedGenUIComponents } from "./entities/GenUIComponentCache";
 export { createOutgoingMessage } from "./entities/Message";
 export type { Conversation, ConversationStatus } from "./entities/Conversation";
 export type {

--- a/packages/core/src/domain/ports/IConnector.ts
+++ b/packages/core/src/domain/ports/IConnector.ts
@@ -8,7 +8,11 @@
  */
 
 import type { IncomingMessage, OutgoingMessage, HistoryResult, MessageStatus } from "../entities/Message";
-import type { GenUIChunkHandler } from "../entities/GenUI";
+import type {
+  GenUIChunkHandler,
+  GenUIComponentsHandler,
+  GenUIEventOptions,
+} from "../entities/GenUI";
 import type { ToolCallHandler } from "../entities/ToolCall";
 import type { Conversation } from "../entities/Conversation";
 import type { ChativaContext } from "../../application/ChativaContext";
@@ -95,6 +99,20 @@ export interface IConnector {
   onGenUIChunk?(callback: GenUIChunkHandler): void;
 
   /**
+   * Optional: register a callback for server-defined GenUI components.
+   *
+   * A backend that authors its own components announces them once the session
+   * is established (mekik sends a `genui_components` frame right after
+   * `welcome`). ChatEngine forwards them to `genUIDefinitionStore`, where
+   * `@chativa/genui` picks them up and registers them — so a `{ type: "ui" }`
+   * chunk naming one of them mounts with no client-side build step.
+   *
+   * May fire more than once (reconnect, hot reload); later definitions of the
+   * same `name` + `version` are ignored.
+   */
+  onGenUIComponents?(callback: GenUIComponentsHandler): void;
+
+  /**
    * Optional: register a callback for tool-call lifecycle events.
    * Connectors report each invocation as it progresses by emitting the same
    * ToolCall `id` with updated fields (running → completed/error).
@@ -107,8 +125,16 @@ export interface IConnector {
    * @param streamId  Original connector stream id (from `onGenUIChunk`).
    * @param eventType The event type string (e.g. "form_submit").
    * @param payload   Arbitrary payload from the UI component.
+   * @param opts      Routing metadata — which attribute fired the interaction and
+   *                  which component it came from. Only protocols that model the
+   *                  distinction use it; ignoring it is fine.
    */
-  receiveComponentEvent?(streamId: string, eventType: string, payload: unknown): void;
+  receiveComponentEvent?(
+    streamId: string,
+    eventType: string,
+    payload: unknown,
+    opts?: GenUIEventOptions
+  ): void;
 
   // ── Multi-conversation / Agent-panel support (all optional) ──────────
 

--- a/packages/core/src/frames.ts
+++ b/packages/core/src/frames.ts
@@ -17,3 +17,14 @@
 
 export type { ChatFrame, ParseChatFrameOptions } from "./domain/entities/ChatFrame";
 export { parseChatFrame, createGenUIEventFrame } from "./domain/entities/ChatFrame";
+
+// The component-catalog cache: pure logic plus an injectable storage adapter, so
+// a connector can do the ETag handshake without pulling in the package root.
+export { createGenUIComponentCache } from "./domain/entities/GenUIComponentCache";
+export type {
+  GenUIComponentCache,
+  GenUIComponentCacheOptions,
+  GenUIComponentCacheStorage,
+  CachedGenUIComponents,
+} from "./domain/entities/GenUIComponentCache";
+export type { GenUIComponentDefinition } from "./domain/entities/GenUI";

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -5,3 +5,8 @@ export * from "./application/index";
 // ── UI base utilities ─────────────────────────────────────────────────────────
 export { I18nMixin, i18next, t } from "./ui/I18nMixin";
 export { ChativaElement } from "./ui/ChativaElement";
+export { GenUIElement, GENUI_COMPONENT_EVENT } from "./ui/GenUIElement";
+export type { GenUIComponentEventDetail } from "./ui/GenUIElement";
+export { GenUIHtmlElement, sanitizeHtml } from "./ui/GenUIHtmlElement";
+export { defineGenUIComponent, clearDefinedGenUIComponents } from "./ui/defineGenUIComponent";
+export { renderTemplate, escapeHtml } from "./ui/template";

--- a/packages/core/src/ui/GenUIElement.ts
+++ b/packages/core/src/ui/GenUIElement.ts
@@ -1,0 +1,147 @@
+import type { GenUIComponentAPI, GenUIEventOptions } from "../domain/entities/GenUI";
+import { ChativaElement } from "./ChativaElement";
+import { i18next, t } from "./I18nMixin";
+
+/** Event name used by the fallback `sendEvent` when no host injected one. */
+export const GENUI_COMPONENT_EVENT = "genui-component-event";
+
+/** `detail` shape of the {@link GENUI_COMPONENT_EVENT} fallback event. */
+export interface GenUIComponentEventDetail extends GenUIEventOptions {
+  eventType: string;
+  payload: unknown;
+}
+
+/**
+ * `GenUIElement` — base class for Generative UI components.
+ *
+ * Extend this instead of `LitElement` when you build a component that a
+ * connector streams as a `{ type: "ui" }` chunk. On top of `ChativaElement`
+ * (i18n + auto re-render on locale switch) it implements the whole
+ * `GenUIComponentAPI` with working defaults, so `this.sendEvent(...)`,
+ * `this.listenEvent(...)` and `this.tFn(...)` are always callable — no
+ * optional-chaining, no four lines of injected-property boilerplate.
+ *
+ * When the component is mounted by `GenUIMessage`, the host assigns its own
+ * message-scoped `sendEvent` / `listenEvent` / `tFn` / `onLangChange` as own
+ * properties, which shadow these prototype defaults. Outside a chat message
+ * (standalone page, Storybook, unit test) the defaults keep the component
+ * functional:
+ *
+ * - `sendEvent`   → dispatches a bubbling, composed `genui-component-event`
+ * - `listenEvent` → registers locally; deliver with `receiveEvent(type, payload)`
+ * - `tFn`         → the shared i18next instance
+ * - `onLangChange`→ the shared i18next instance
+ *
+ * @example
+ * ```ts
+ * import { GenUIElement } from "@chativa/core";
+ * import { html, css } from "lit";
+ * import { customElement, property } from "lit/decorators.js";
+ *
+ * @customElement("weather-widget")
+ * export class WeatherWidget extends GenUIElement {
+ *   static override styles = css`:host { display: block; }`;
+ *
+ *   @property({ type: String }) city = "";
+ *   @property({ type: Number }) temp = 0;
+ *
+ *   override connectedCallback() {
+ *     super.connectedCallback();
+ *     this.listenEvent("weather_updated", (p) => {
+ *       this.temp = (p as { temp: number }).temp;
+ *     });
+ *   }
+ *
+ *   override render() {
+ *     return html`
+ *       <h3>${this.city} · ${this.temp}°C</h3>
+ *       <button @click=${() => this.sendEvent("refresh_weather", { city: this.city })}>
+ *         ${this.tFn("widget.refresh", "Refresh")}
+ *       </button>
+ *     `;
+ *   }
+ * }
+ *
+ * GenUIRegistry.register("weather", WeatherWidget);
+ * ```
+ *
+ * Note: do NOT redeclare `sendEvent` / `listenEvent` / `tFn` / `onLangChange`
+ * as class fields in the subclass — that shadows the defaults with `undefined`.
+ */
+export class GenUIElement extends ChativaElement implements GenUIComponentAPI {
+  /**
+   * Listeners registered through the default `listenEvent`. Unused when a host
+   * injects its own implementation.
+   */
+  private _localListeners = new Map<string, Set<(payload: unknown) => void>>();
+
+  /**
+   * Send an event to the connector.
+   *
+   * Replaced by `GenUIMessage` with a message-scoped version that routes to
+   * `IConnector.receiveComponentEvent`. The default dispatches a bubbling,
+   * composed `genui-component-event` so a plain host page can still react.
+   */
+  sendEvent(type: string, payload: unknown, opts?: GenUIEventOptions): void {
+    this.dispatchEvent(
+      new CustomEvent<GenUIComponentEventDetail>(GENUI_COMPONENT_EVENT, {
+        detail: { eventType: type, payload, ...opts },
+        bubbles: true,
+        composed: true,
+      })
+    );
+  }
+
+  /**
+   * Subscribe to a server-originated event.
+   *
+   * Replaced by `GenUIMessage` with a version scoped to this message bubble.
+   * The default keeps listeners locally — feed them with `receiveEvent()`.
+   */
+  listenEvent(type: string, cb: (payload: unknown) => void): void {
+    let set = this._localListeners.get(type);
+    if (!set) {
+      set = new Set();
+      this._localListeners.set(type, set);
+    }
+    set.add(cb);
+  }
+
+  /**
+   * Deliver an event to listeners registered through the *default*
+   * `listenEvent`. Useful in tests and standalone hosts; a no-op once
+   * `GenUIMessage` has injected its own `listenEvent`.
+   */
+  receiveEvent(type: string, payload?: unknown): void {
+    this._localListeners.get(type)?.forEach((cb) => cb(payload));
+  }
+
+  /**
+   * Translate a key, falling back to `fallback` (then the key itself).
+   *
+   * Named `tFn` — not `translate` — because `HTMLElement.translate` is a native
+   * boolean attribute. `this.t(key, options)` from `ChativaElement` is also
+   * available when you need full i18next options.
+   */
+  tFn(key: string, fallback?: string): string {
+    return t(key, { defaultValue: fallback ?? key }) as string;
+  }
+
+  /**
+   * Subscribe to locale changes; returns an unsubscribe function.
+   *
+   * Subclasses rarely need this — `ChativaElement` already re-renders on
+   * `languageChanged`. It exists so the injected API stays complete.
+   */
+  onLangChange(cb: () => void): () => void {
+    i18next.on("languageChanged", cb);
+    return () => {
+      i18next.off("languageChanged", cb);
+    };
+  }
+
+  override disconnectedCallback(): void {
+    super.disconnectedCallback();
+    this._localListeners.clear();
+  }
+}

--- a/packages/core/src/ui/GenUIHtmlElement.ts
+++ b/packages/core/src/ui/GenUIHtmlElement.ts
@@ -1,0 +1,239 @@
+import { html, nothing, type PropertyDeclarations, type TemplateResult } from "lit";
+import { unsafeHTML } from "lit/directives/unsafe-html.js";
+import type { GenUIEventScope } from "../domain/entities/GenUI";
+import { GenUIElement } from "./GenUIElement";
+
+/** Tags dropped by {@link sanitizeHtml} — they execute code or load remote documents. */
+const BLOCKED_TAGS = new Set([
+  "SCRIPT", "IFRAME", "OBJECT", "EMBED", "LINK", "META", "BASE", "FRAME", "FRAMESET", "NOSCRIPT",
+]);
+
+/** Attributes whose value is a URL and therefore needs a scheme check. */
+const URL_ATTRS = new Set(["href", "src", "action", "formaction", "poster", "xlink:href", "srcset"]);
+
+/** Schemes allowed in URL attributes. Notably excludes `javascript:` and `vbscript:`. */
+const SAFE_SCHEMES = new Set(["http", "https", "mailto", "tel", "sms", "ftp"]);
+
+/** `data:` is only allowed for images. */
+const DATA_IMAGE = /^data:image\/[a-z0-9.+-]+[;,]/i;
+
+/**
+ * Relative URLs are fine; an absolute one must use a scheme we trust.
+ *
+ * Whitespace and control characters are stripped first — `java\tscript:` is the
+ * classic way past a naive prefix check.
+ */
+function isSafeUrl(value: string): boolean {
+  const v = value.replace(/[\s\u0000-\u001F]/g, "");
+  const scheme = /^([a-z][a-z0-9+.-]*):/i.exec(v);
+  if (!scheme) return true;
+  if (DATA_IMAGE.test(v)) return true;
+  return SAFE_SCHEMES.has(scheme[1]!.toLowerCase());
+}
+
+/**
+ * Strip anything script-like out of untrusted markup.
+ *
+ * Removes {@link BLOCKED_TAGS}, every `on*` event attribute, and URL attributes
+ * whose scheme isn't trusted (`javascript:`, `vbscript:`, …).
+ * Everything else — structure, classes, inline styles — is left intact.
+ *
+ * Exported so hosts can pre-sanitize markup before it reaches the widget.
+ */
+export function sanitizeHtml(markup: string): string {
+  const tpl = document.createElement("template");
+  tpl.innerHTML = markup;
+
+  for (const el of Array.from(tpl.content.querySelectorAll("*"))) {
+    if (BLOCKED_TAGS.has(el.tagName)) {
+      el.remove();
+      continue;
+    }
+    for (const attr of Array.from(el.attributes)) {
+      const name = attr.name.toLowerCase();
+      if (name.startsWith("on")) {
+        el.removeAttribute(attr.name);
+      } else if (URL_ATTRS.has(name) && !isSafeUrl(attr.value)) {
+        el.removeAttribute(attr.name);
+      }
+    }
+  }
+
+  return tpl.innerHTML;
+}
+
+/**
+ * `<chativa-html>` — render markup that arrives from anywhere.
+ *
+ * The escape hatch for teams that don't want to compile a LitElement per widget:
+ * a backend streams a chunk, a React app sets a prop, or a plain HTML page
+ * writes children — the same element renders it and routes interactions back to
+ * the connector.
+ *
+ * ### 1. From a connector / backend
+ * ```json
+ * { "type": "ui", "component": "genui-html",
+ *   "props": {
+ *     "html": "<div class='card'><h3>Order #123</h3><button data-event='track_order' data-payload='{\"id\":123}'>Track</button></div>",
+ *     "css":  ".card { border: 1px solid #e2e8f0; border-radius: 12px; padding: 12px; }"
+ *   } }
+ * ```
+ * The button click arrives at the connector via `receiveComponentEvent(streamId, "track_order", { id: 123 })`.
+ *
+ * ### 2. From plain HTML (children are used when no `html` prop is set)
+ * ```html
+ * <chativa-html>
+ *   <button data-event="say_hi">Hi</button>
+ * </chativa-html>
+ * ```
+ *
+ * ### 3. From React
+ * ```tsx
+ * <chativa-html
+ *   ref={(el) => { if (el) el.html = markup; }}
+ *   onGenuiComponentEvent={...}  // or: el.addEventListener("genui-component-event", ...)
+ * />
+ * ```
+ *
+ * ### Interaction contract
+ *
+ * A click (or form submit) on an element carrying an event attribute sends that
+ * event. Which attribute you use says **who the interaction is addressed to**,
+ * for backends that model the distinction (mekik `PROTOCOL.md` §10.4):
+ *
+ * | attribute | `scope` sent | meaning |
+ * | --- | --- | --- |
+ * | `component-event="<name>"` | `"component"` | the widget's own conversation with the node that mounted it |
+ * | `mekik-event="<name>"` | `"graph"` | the application, which may start a new turn |
+ * | `data-event="<name>"` | none | let the backend decide (the original form) |
+ *
+ * Only the most specific attribute on an element is used, in the order above. An
+ * empty value is not a trigger.
+ *
+ * - `data-payload='<json>'` → parsed and sent as the payload (invalid JSON is
+ *   sent as the raw string).
+ * - A `<form component-event="...">` (or `mekik-event` / `data-event`) sends its
+ *   named fields, merged over `data-payload`, and its default submit is prevented.
+ *
+ * ### Safety
+ * Markup is sanitized by default ({@link sanitizeHtml}). Set the `unsafe`
+ * attribute/property to render it verbatim — only for markup you control, since
+ * it re-enables `<script>` and inline handlers.
+ */
+export class GenUIHtmlElement extends GenUIElement {
+  static override properties: PropertyDeclarations = {
+    html: { type: String },
+    css: { type: String },
+    unsafe: { type: Boolean },
+  };
+
+  /** Markup to render. When empty, the element's light-DOM children are shown. */
+  html = "";
+
+  /** Optional CSS, scoped to this element's shadow root. */
+  css = "";
+
+  /** Skip sanitization. Only for markup you fully control. */
+  unsafe = false;
+
+  /**
+   * Delegate interactions on the shadow root — it has the same lifetime as the
+   * element, and slotted light-DOM children bubble through it too, so both the
+   * `html` prop and the children form work with one pair of listeners.
+   */
+  override createRenderRoot(): HTMLElement | DocumentFragment {
+    const root = super.createRenderRoot();
+    root.addEventListener("click", this._onClick);
+    root.addEventListener("submit", this._onSubmit);
+    return root;
+  }
+
+  /**
+   * The event attributes, most specific first. The attribute an author writes is
+   * how they say *who the interaction is for* — see {@link GenUIEventScope}.
+   */
+  private static readonly EVENT_ATTRS: ReadonlyArray<{ attr: string; scope?: GenUIEventScope }> = [
+    { attr: "component-event", scope: "component" },
+    { attr: "mekik-event", scope: "graph" },
+    { attr: "data-event" },
+  ];
+
+  /** Nearest ancestor carrying an event attribute, searched only within this element. */
+  private _findTrigger(e: Event): { el: HTMLElement; name: string; scope?: GenUIEventScope } | null {
+    for (const node of e.composedPath()) {
+      if (node === this || node === this.renderRoot) break;
+      if (!(node instanceof HTMLElement)) continue;
+      for (const { attr, scope } of GenUIHtmlElement.EVENT_ATTRS) {
+        const name = node.getAttribute(attr);
+        // An empty value is not a name — treat it as "not a trigger" rather than
+        // firing an event nothing can be listening for.
+        if (name) return { el: node, name, ...(scope ? { scope } : {}) };
+      }
+    }
+    return null;
+  }
+
+  /** `data-payload` as JSON; the raw string when it isn't valid JSON. */
+  private _payloadOf(el: HTMLElement): unknown {
+    const raw = el.getAttribute("data-payload");
+    if (raw === null) return {};
+    try {
+      return JSON.parse(raw);
+    } catch {
+      return raw;
+    }
+  }
+
+  /**
+   * Send the interaction, passing routing metadata only when the markup declared
+   * it — a plain `data-event` keeps the two-argument call it has always made.
+   */
+  private _send(trigger: { scope?: GenUIEventScope; name: string }, payload: unknown): void {
+    if (trigger.scope) this.sendEvent(trigger.name, payload, { scope: trigger.scope });
+    else this.sendEvent(trigger.name, payload);
+  }
+
+  private _onClick = (e: Event): void => {
+    const trigger = this._findTrigger(e);
+    if (!trigger || trigger.el instanceof HTMLFormElement) return;
+    this._send(trigger, this._payloadOf(trigger.el));
+  };
+
+  private _onSubmit = (e: Event): void => {
+    const trigger = this._findTrigger(e);
+    if (!trigger || !(trigger.el instanceof HTMLFormElement)) return;
+    const form = trigger.el;
+    e.preventDefault();
+
+    const base = this._payloadOf(form);
+    const fields = Object.fromEntries(new FormData(form).entries());
+    const payload =
+      base && typeof base === "object" ? { ...(base as Record<string, unknown>), ...fields } : fields;
+
+    this._send(trigger, payload);
+  };
+
+  /**
+   * The markup to render, before sanitization.
+   *
+   * Subclasses override this to compute markup from something other than the
+   * `html` prop — `defineGenUIComponent` renders a server-supplied template
+   * against the component's declared props here.
+   */
+  protected markup(): string {
+    return this.html;
+  }
+
+  override render(): TemplateResult {
+    const raw = this.markup();
+    const markup = this.unsafe ? raw : sanitizeHtml(raw);
+    return html`
+      ${this.css ? html`<style>${this.css}</style>` : nothing}
+      ${raw ? unsafeHTML(markup) : html`<slot></slot>`}
+    `;
+  }
+}
+
+if (!customElements.get("chativa-html")) {
+  customElements.define("chativa-html", GenUIHtmlElement);
+}

--- a/packages/core/src/ui/__tests__/GenUIElement.test.ts
+++ b/packages/core/src/ui/__tests__/GenUIElement.test.ts
@@ -1,0 +1,118 @@
+import { describe, it, expect, vi, beforeAll } from "vitest";
+import i18next from "i18next";
+import { GenUIElement, GENUI_COMPONENT_EVENT } from "../GenUIElement";
+import type { GenUIComponentEventDetail } from "../GenUIElement";
+
+class TestWidget extends GenUIElement {}
+customElements.define("test-genui-widget", TestWidget);
+
+beforeAll(async () => {
+  await i18next.init({
+    lng: "en",
+    resources: { en: { translation: { "test.hello": "Hello" } } },
+  });
+});
+
+describe("GenUIElement", () => {
+  it("dispatches a bubbling composed event from the default sendEvent", () => {
+    const el = new TestWidget();
+    document.body.appendChild(el);
+
+    const spy = vi.fn();
+    document.body.addEventListener(GENUI_COMPONENT_EVENT, spy as EventListener);
+    el.sendEvent("refresh_weather", { city: "Istanbul" });
+
+    expect(spy).toHaveBeenCalledTimes(1);
+    const e = spy.mock.calls[0]![0] as CustomEvent<GenUIComponentEventDetail>;
+    expect(e.detail).toEqual({ eventType: "refresh_weather", payload: { city: "Istanbul" } });
+    expect(e.bubbles).toBe(true);
+    expect(e.composed).toBe(true);
+
+    document.body.removeEventListener(GENUI_COMPONENT_EVENT, spy as EventListener);
+    el.remove();
+  });
+
+  it("an injected sendEvent shadows the default", () => {
+    const el = new TestWidget();
+    const injected = vi.fn();
+    const dom = vi.fn();
+    el.addEventListener(GENUI_COMPONENT_EVENT, dom as EventListener);
+
+    // Mirrors what GenUIMessage does at mount time.
+    (el as unknown as Record<string, unknown>)["sendEvent"] = injected;
+    el.sendEvent("form_submit", { a: 1 });
+
+    expect(injected).toHaveBeenCalledWith("form_submit", { a: 1 });
+    expect(dom).not.toHaveBeenCalled();
+  });
+
+  it("default listenEvent + receiveEvent deliver payloads", () => {
+    const el = new TestWidget();
+    const cb = vi.fn();
+    el.listenEvent("weather_updated", cb);
+    el.receiveEvent("weather_updated", { temp: 21 });
+
+    expect(cb).toHaveBeenCalledWith({ temp: 21 });
+  });
+
+  it("receiveEvent ignores unknown event types", () => {
+    const el = new TestWidget();
+    const cb = vi.fn();
+    el.listenEvent("known", cb);
+    el.receiveEvent("unknown", {});
+
+    expect(cb).not.toHaveBeenCalled();
+  });
+
+  it("supports multiple listeners for the same type", () => {
+    const el = new TestWidget();
+    const a = vi.fn();
+    const b = vi.fn();
+    el.listenEvent("ping", a);
+    el.listenEvent("ping", b);
+    el.receiveEvent("ping");
+
+    expect(a).toHaveBeenCalledOnce();
+    expect(b).toHaveBeenCalledOnce();
+  });
+
+  it("clears local listeners on disconnect", () => {
+    const el = new TestWidget();
+    document.body.appendChild(el);
+    const cb = vi.fn();
+    el.listenEvent("ping", cb);
+    el.remove();
+    el.receiveEvent("ping");
+
+    expect(cb).not.toHaveBeenCalled();
+  });
+
+  it("tFn translates a known key", () => {
+    const el = new TestWidget();
+    expect(el.tFn("test.hello")).toBe("Hello");
+  });
+
+  it("tFn falls back to the given fallback, then to the key", () => {
+    const el = new TestWidget();
+    expect(el.tFn("test.missing", "Fallback")).toBe("Fallback");
+    expect(el.tFn("test.missing")).toBe("test.missing");
+  });
+
+  it("onLangChange subscribes and returns a working unsubscribe", () => {
+    const el = new TestWidget();
+    const cb = vi.fn();
+    const unsub = el.onLangChange(cb);
+
+    i18next.emit("languageChanged", "tr");
+    expect(cb).toHaveBeenCalledTimes(1);
+
+    unsub();
+    i18next.emit("languageChanged", "en");
+    expect(cb).toHaveBeenCalledTimes(1);
+  });
+
+  it("inherits the ChativaElement i18n helper", () => {
+    const el = new TestWidget();
+    expect((el as unknown as { t(k: string): string }).t("test.hello")).toBe("Hello");
+  });
+});

--- a/packages/core/src/ui/__tests__/GenUIHtmlElement.test.ts
+++ b/packages/core/src/ui/__tests__/GenUIHtmlElement.test.ts
@@ -1,0 +1,239 @@
+import { describe, it, expect, vi } from "vitest";
+import { GenUIHtmlElement, sanitizeHtml } from "../GenUIHtmlElement";
+
+/** Mount, set props, wait for Lit's update cycle. */
+async function mount(props: Partial<GenUIHtmlElement> = {}, children = ""): Promise<GenUIHtmlElement> {
+  const el = new GenUIHtmlElement();
+  if (children) el.innerHTML = children;
+  Object.assign(el, props);
+  document.body.appendChild(el);
+  await el.updateComplete;
+  return el;
+}
+
+const shadowHtml = (el: GenUIHtmlElement) => (el.shadowRoot?.innerHTML ?? "");
+
+describe("sanitizeHtml", () => {
+  it("drops script tags", () => {
+    expect(sanitizeHtml("<div>ok</div><script>alert(1)</script>")).toBe("<div>ok</div>");
+  });
+
+  it("drops iframes and other document-loading tags", () => {
+    const out = sanitizeHtml("<iframe src='https://evil.test'></iframe><object></object><p>keep</p>");
+    expect(out).toBe("<p>keep</p>");
+  });
+
+  it("strips inline event handlers", () => {
+    const out = sanitizeHtml(`<button onclick="alert(1)" onmouseover="x()">Go</button>`);
+    expect(out).toBe("<button>Go</button>");
+  });
+
+  it("strips javascript: URLs but keeps safe ones", () => {
+    expect(sanitizeHtml(`<a href="javascript:alert(1)">x</a>`)).toBe("<a>x</a>");
+    expect(sanitizeHtml(`<a href="vbscript:msgbox">x</a>`)).toBe("<a>x</a>");
+    expect(sanitizeHtml(`<a href="https://ok.test">x</a>`)).toContain(`href="https://ok.test"`);
+    expect(sanitizeHtml(`<a href="mailto:a@b.c">x</a>`)).toContain(`href="mailto:a@b.c"`);
+  });
+
+  it("sees through whitespace/control-char obfuscation of javascript:", () => {
+    expect(sanitizeHtml(`<a href="java\tscript:alert(1)">x</a>`)).toBe("<a>x</a>");
+    expect(sanitizeHtml(`<a href="  JaVaScRiPt:alert(1)">x</a>`)).toBe("<a>x</a>");
+  });
+
+  it("keeps relative URLs", () => {
+    expect(sanitizeHtml(`<img src="images/a.png">`)).toContain(`src="images/a.png"`);
+    expect(sanitizeHtml(`<a href="/local">x</a>`)).toContain(`href="/local"`);
+    expect(sanitizeHtml(`<a href="../up">x</a>`)).toContain(`href="../up"`);
+    expect(sanitizeHtml(`<a href="#anchor">x</a>`)).toContain(`href="#anchor"`);
+    expect(sanitizeHtml(`<img srcset="a.png 1x, b.png 2x">`)).toContain(`srcset="a.png 1x, b.png 2x"`);
+  });
+
+  it("allows data: URLs for images only", () => {
+    expect(sanitizeHtml(`<img src="data:image/png;base64,AAA">`)).toContain("data:image/png");
+    expect(sanitizeHtml(`<a href="data:text/html,<script>1</script>">x</a>`)).not.toContain("data:text/html");
+  });
+
+  it("keeps structure, classes and inline styles", () => {
+    const markup = `<div class="card" style="color: red"><h3>Title</h3></div>`;
+    expect(sanitizeHtml(markup)).toBe(markup);
+  });
+
+  it("keeps data-event / data-payload hooks intact", () => {
+    const markup = `<button data-event="track" data-payload="{&quot;id&quot;:1}">Track</button>`;
+    expect(sanitizeHtml(markup)).toContain(`data-event="track"`);
+  });
+});
+
+describe("GenUIHtmlElement", () => {
+  it("is defined as <chativa-html>", () => {
+    expect(customElements.get("chativa-html")).toBe(GenUIHtmlElement);
+  });
+
+  it("renders sanitized markup from the html prop", async () => {
+    const el = await mount({ html: `<p class="x">hi</p><script>alert(1)</script>` });
+    expect(shadowHtml(el)).toContain(`<p class="x">hi</p>`);
+    expect(shadowHtml(el)).not.toContain("script");
+  });
+
+  it("renders markup verbatim when unsafe is set", async () => {
+    const el = await mount({ html: `<b onclick="x()">hi</b>`, unsafe: true });
+    expect(shadowHtml(el)).toContain("onclick");
+  });
+
+  it("injects the css prop into the shadow root", async () => {
+    const el = await mount({ html: "<p>hi</p>", css: ".x { color: red; }" });
+    const style = el.shadowRoot!.querySelector("style");
+    expect(style).not.toBeNull();
+    expect(style!.textContent).toContain(".x { color: red; }");
+  });
+
+  it("falls back to a slot when no html prop is set", async () => {
+    const el = await mount({}, "<b>child</b>");
+    expect(shadowHtml(el)).toContain("<slot>");
+  });
+
+  it("re-renders when the backend streams new markup", async () => {
+    const el = await mount({ html: "<p>first</p>" });
+    el.html = "<p>second</p>";
+    await el.updateComplete;
+    expect(shadowHtml(el)).toContain("second");
+    expect(shadowHtml(el)).not.toContain("first");
+  });
+
+  it("sends data-event clicks through sendEvent", async () => {
+    const el = await mount({ html: `<button data-event="track_order" data-payload='{"id":123}'>Track</button>` });
+    const sent = vi.fn();
+    (el as unknown as Record<string, unknown>)["sendEvent"] = sent;
+
+    el.shadowRoot!.querySelector("button")!.click();
+
+    expect(sent).toHaveBeenCalledWith("track_order", { id: 123 });
+  });
+
+  it("finds the data-event ancestor when an inner node is clicked", async () => {
+    const el = await mount({ html: `<div data-event="card_click"><span>inner</span></div>` });
+    const sent = vi.fn();
+    (el as unknown as Record<string, unknown>)["sendEvent"] = sent;
+
+    el.shadowRoot!.querySelector("span")!.dispatchEvent(new MouseEvent("click", { bubbles: true, composed: true }));
+
+    expect(sent).toHaveBeenCalledWith("card_click", {});
+  });
+
+  it("passes a non-JSON data-payload through as a raw string", async () => {
+    const el = await mount({ html: `<button data-event="pick" data-payload="blue">Blue</button>` });
+    const sent = vi.fn();
+    (el as unknown as Record<string, unknown>)["sendEvent"] = sent;
+
+    el.shadowRoot!.querySelector("button")!.click();
+
+    expect(sent).toHaveBeenCalledWith("pick", "blue");
+  });
+
+  it("ignores clicks on elements without data-event", async () => {
+    const el = await mount({ html: `<button>plain</button>` });
+    const sent = vi.fn();
+    (el as unknown as Record<string, unknown>)["sendEvent"] = sent;
+
+    el.shadowRoot!.querySelector("button")!.click();
+
+    expect(sent).not.toHaveBeenCalled();
+  });
+
+  it("submits form fields merged over data-payload", async () => {
+    const el = await mount({
+      html: `<form data-event="lead_form" data-payload='{"source":"chat","name":"default"}'>
+               <input name="name" value="Hamza" />
+               <input name="email" value="a@b.c" />
+             </form>`,
+    });
+    const sent = vi.fn();
+    (el as unknown as Record<string, unknown>)["sendEvent"] = sent;
+
+    const form = el.shadowRoot!.querySelector("form")!;
+    const evt = new Event("submit", { bubbles: true, cancelable: true, composed: true });
+    form.dispatchEvent(evt);
+
+    expect(evt.defaultPrevented).toBe(true);
+    expect(sent).toHaveBeenCalledWith("lead_form", { source: "chat", name: "Hamza", email: "a@b.c" });
+  });
+
+  it("emits the fallback DOM event when no host injected sendEvent", async () => {
+    const el = await mount({ html: `<button data-event="say_hi">Hi</button>` });
+    const spy = vi.fn();
+    document.body.addEventListener("genui-component-event", spy as EventListener);
+
+    el.shadowRoot!.querySelector("button")!.click();
+
+    expect(spy).toHaveBeenCalledOnce();
+    const e = spy.mock.calls[0]![0] as CustomEvent;
+    expect(e.detail).toEqual({ eventType: "say_hi", payload: {} });
+
+    document.body.removeEventListener("genui-component-event", spy as EventListener);
+  });
+
+  // ── event scope: who the interaction is addressed to ──────────────────────
+
+  describe("event scope", () => {
+    /** Click the only button and return the args `sendEvent` was called with. */
+    async function clickWith(markup: string): Promise<unknown[]> {
+      const el = await mount({ html: markup });
+      const sent = vi.fn();
+      (el as unknown as Record<string, unknown>)["sendEvent"] = sent;
+      el.shadowRoot!.querySelector("button")!.click();
+      return sent.mock.calls[0] ?? [];
+    }
+
+    it("sends scope 'component' for a component-event attribute", async () => {
+      expect(await clickWith(`<button component-event="rate_delivery" data-payload='{"stars":5}'>Rate</button>`))
+        .toEqual(["rate_delivery", { stars: 5 }, { scope: "component" }]);
+    });
+
+    it("sends scope 'graph' for a mekik-event attribute", async () => {
+      expect(await clickWith(`<button mekik-event="track_order" data-payload='{"id":"ORD-42"}'>Track</button>`))
+        .toEqual(["track_order", { id: "ORD-42" }, { scope: "graph" }]);
+    });
+
+    it("sends no scope for a plain data-event — the backend decides", async () => {
+      expect(await clickWith(`<button data-event="track_order">Track</button>`))
+        .toEqual(["track_order", {}]);
+    });
+
+    it("prefers the most specific attribute when an element carries several", async () => {
+      expect(await clickWith(`<button component-event="mine" mekik-event="theirs" data-event="legacy">Go</button>`))
+        .toEqual(["mine", {}, { scope: "component" }]);
+    });
+
+    it("treats an empty event name as no trigger at all", async () => {
+      expect(await clickWith(`<button component-event="">Go</button>`)).toEqual([]);
+    });
+
+    it("carries the scope through a form submit too", async () => {
+      const el = await mount({
+        html: `<form component-event="rate_delivery"><input name="stars" value="5" /></form>`,
+      });
+      const sent = vi.fn();
+      (el as unknown as Record<string, unknown>)["sendEvent"] = sent;
+
+      const form = el.shadowRoot!.querySelector("form")!;
+      const evt = new Event("submit", { bubbles: true, cancelable: true, composed: true });
+      form.dispatchEvent(evt);
+
+      expect(evt.defaultPrevented).toBe(true);
+      expect(sent).toHaveBeenCalledWith("rate_delivery", { stars: "5" }, { scope: "component" });
+    });
+
+    it("puts the scope on the fallback DOM event's detail", async () => {
+      const el = await mount({ html: `<button mekik-event="track_order">Track</button>` });
+      const spy = vi.fn();
+      document.body.addEventListener("genui-component-event", spy as EventListener);
+
+      el.shadowRoot!.querySelector("button")!.click();
+
+      const e = spy.mock.calls[0]![0] as CustomEvent;
+      expect(e.detail).toEqual({ eventType: "track_order", payload: {}, scope: "graph" });
+
+      document.body.removeEventListener("genui-component-event", spy as EventListener);
+    });
+  });
+});

--- a/packages/core/src/ui/__tests__/defineGenUIComponent.test.ts
+++ b/packages/core/src/ui/__tests__/defineGenUIComponent.test.ts
@@ -1,0 +1,158 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { GenUIComponentDefinition } from "../../domain/entities/GenUI";
+import { defineGenUIComponent, clearDefinedGenUIComponents } from "../defineGenUIComponent";
+import { GenUIHtmlElement } from "../GenUIHtmlElement";
+
+const ORDER_CARD: GenUIComponentDefinition = {
+  name: "order-card",
+  template: `<div class="card"><h3>{{title}}</h3>
+    {{#each lines}}<p>{{this.label}}</p>{{/each}}
+    <button data-event="track_order" data-payload='{"id":"{{id}}"}'>Track</button></div>`,
+  css: ".card { padding: 12px; }",
+  props: { id: "", title: "", lines: [] },
+};
+
+async function mount(Ctor: typeof GenUIHtmlElement, props: Record<string, unknown> = {}) {
+  const el = new Ctor();
+  Object.assign(el, props);
+  document.body.appendChild(el);
+  await el.updateComplete;
+  return el;
+}
+
+beforeEach(() => clearDefinedGenUIComponents());
+
+describe("defineGenUIComponent", () => {
+  it("renders the template against the props", async () => {
+    const el = await mount(defineGenUIComponent(ORDER_CARD), {
+      id: "A1",
+      title: "Order #123",
+      lines: [{ label: "Tea" }, { label: "Cake" }],
+    });
+
+    const shadow = el.shadowRoot!.innerHTML;
+    expect(shadow).toContain("Order #123");
+    expect(shadow).toContain("<p>Tea</p>");
+    expect(shadow).toContain("<p>Cake</p>");
+    el.remove();
+  });
+
+  it("applies the definition's css and defaults", async () => {
+    const el = await mount(defineGenUIComponent({
+      name: "greet",
+      template: "<p>{{greeting}}</p>",
+      css: "p { color: red; }",
+      props: { greeting: "Merhaba" },
+    }));
+
+    expect(el.shadowRoot!.querySelector("style")!.textContent).toContain("color: red");
+    expect(el.shadowRoot!.innerHTML).toContain("Merhaba");
+    el.remove();
+  });
+
+  it("re-renders in place when a declared prop changes", async () => {
+    const Ctor = defineGenUIComponent({
+      name: "counter",
+      template: "<p>{{count}}</p>",
+      props: { count: 0 },
+    });
+    const el = await mount(Ctor, { count: 1 });
+    expect(el.shadowRoot!.innerHTML).toContain("<p>1</p>");
+
+    (el as unknown as Record<string, unknown>)["count"] = 2;
+    await el.updateComplete;
+    expect(el.shadowRoot!.innerHTML).toContain("<p>2</p>");
+    el.remove();
+  });
+
+  it("keeps object defaults per-instance instead of aliasing them", async () => {
+    const Ctor = defineGenUIComponent({
+      name: "listy",
+      template: "{{#each items}}x{{/each}}",
+      props: { items: [] },
+    });
+    const a = new Ctor() as unknown as Record<string, unknown>;
+    const b = new Ctor() as unknown as Record<string, unknown>;
+    (a["items"] as unknown[]).push(1);
+
+    expect(a["items"]).toHaveLength(1);
+    expect(b["items"]).toHaveLength(0);
+  });
+
+  it("sanitizes template output — a definition cannot ship a script", async () => {
+    const el = await mount(defineGenUIComponent({
+      name: "sneaky",
+      template: `<p>ok</p><script>alert(1)</script><a href="javascript:alert(1)">x</a>`,
+    }));
+
+    expect(el.shadowRoot!.innerHTML).toContain("<p>ok</p>");
+    expect(el.shadowRoot!.innerHTML).not.toContain("script>");
+    expect(el.shadowRoot!.querySelector("a")!.hasAttribute("href")).toBe(false);
+    el.remove();
+  });
+
+  it("escapes prop values, so props cannot inject markup either", async () => {
+    const el = await mount(defineGenUIComponent({
+      name: "escapey",
+      template: "<p>{{text}}</p>",
+      props: { text: "" },
+    }), { text: "<img src=x onerror=alert(1)>" });
+
+    expect(el.shadowRoot!.querySelector("img")).toBeNull();
+    expect(el.shadowRoot!.innerHTML).toContain("&lt;img");
+    el.remove();
+  });
+
+  it("routes data-event clicks like any other GenUI component", async () => {
+    const el = await mount(defineGenUIComponent(ORDER_CARD), { id: "A1" });
+    const sent = vi.fn();
+    (el as unknown as Record<string, unknown>)["sendEvent"] = sent;
+
+    el.shadowRoot!.querySelector("button")!.click();
+
+    expect(sent).toHaveBeenCalledWith("track_order", { id: "A1" });
+    el.remove();
+  });
+
+  it("returns the same class for the same name@version", () => {
+    expect(defineGenUIComponent(ORDER_CARD)).toBe(defineGenUIComponent({ ...ORDER_CARD }));
+  });
+
+  it("builds a new class when the version changes", () => {
+    const v1 = defineGenUIComponent({ ...ORDER_CARD, version: "1" });
+    const v2 = defineGenUIComponent({ ...ORDER_CARD, version: "2" });
+    expect(v2).not.toBe(v1);
+  });
+
+  it("defines a distinct custom element tag per definition", () => {
+    defineGenUIComponent({ name: "tagged", template: "<p>1</p>" });
+    expect(customElements.get("chativa-genui-tagged")).toBeDefined();
+
+    clearDefinedGenUIComponents();
+    defineGenUIComponent({ name: "tagged", template: "<p>2</p>", version: "2" });
+    // The first tag is taken, so the second definition gets its own.
+    expect(customElements.get("chativa-genui-tagged-1")).toBeDefined();
+  });
+
+  it("honours an explicit tag", () => {
+    defineGenUIComponent({ name: "custom-tag", template: "<p>x</p>", tag: "my-server-widget" });
+    expect(customElements.get("my-server-widget")).toBeDefined();
+  });
+
+  it("refuses to let a definition prop take over html/css/unsafe", async () => {
+    const el = await mount(defineGenUIComponent({
+      name: "hijack",
+      template: "<p>safe</p>",
+      props: { unsafe: true, html: "<script>alert(1)</script>" },
+    }));
+
+    expect(el.unsafe).toBe(false);
+    expect(el.shadowRoot!.innerHTML).not.toContain("script>");
+    el.remove();
+  });
+
+  it("exposes the source definition on the class", () => {
+    const Ctor = defineGenUIComponent(ORDER_CARD) as unknown as { definition: GenUIComponentDefinition };
+    expect(Ctor.definition.name).toBe("order-card");
+  });
+});

--- a/packages/core/src/ui/__tests__/template.test.ts
+++ b/packages/core/src/ui/__tests__/template.test.ts
@@ -1,0 +1,136 @@
+import { describe, it, expect } from "vitest";
+import { renderTemplate, escapeHtml } from "../template";
+
+describe("escapeHtml", () => {
+  it("escapes the characters that could break out of text or an attribute", () => {
+    expect(escapeHtml(`<b>&"'`)).toBe("&lt;b&gt;&amp;&quot;&#39;");
+  });
+
+  it("renders null/undefined as empty", () => {
+    expect(escapeHtml(null)).toBe("");
+    expect(escapeHtml(undefined)).toBe("");
+  });
+
+  it("stringifies numbers and booleans", () => {
+    expect(escapeHtml(0)).toBe("0");
+    expect(escapeHtml(false)).toBe("false");
+  });
+});
+
+describe("renderTemplate — interpolation", () => {
+  it("substitutes a top-level value", () => {
+    expect(renderTemplate("<h3>{{title}}</h3>", { title: "Order" })).toBe("<h3>Order</h3>");
+  });
+
+  it("walks a dotted path", () => {
+    expect(renderTemplate("{{user.name}}", { user: { name: "Hamza" } })).toBe("Hamza");
+  });
+
+  it("tolerates whitespace inside the tag", () => {
+    expect(renderTemplate("{{  title  }}", { title: "x" })).toBe("x");
+  });
+
+  it("renders an unknown path as empty", () => {
+    expect(renderTemplate("[{{nope.deep}}]", { title: "x" })).toBe("[]");
+  });
+
+  it("escapes interpolated values — a prop cannot inject markup", () => {
+    const out = renderTemplate("<p>{{text}}</p>", { text: "<script>alert(1)</script>" });
+    expect(out).toBe("<p>&lt;script&gt;alert(1)&lt;/script&gt;</p>");
+  });
+
+  it("escapes quotes so an attribute cannot be broken out of", () => {
+    const out = renderTemplate(`<a title="{{t}}">x</a>`, { t: `" onmouseover="alert(1)` });
+    expect(out).not.toContain(`onmouseover="`);
+    expect(out).toContain("&quot;");
+  });
+});
+
+describe("renderTemplate — #if", () => {
+  it("renders the body when truthy", () => {
+    expect(renderTemplate("{{#if ok}}yes{{/if}}", { ok: true })).toBe("yes");
+  });
+
+  it("skips the body when falsy", () => {
+    expect(renderTemplate("{{#if ok}}yes{{/if}}", { ok: false })).toBe("");
+    expect(renderTemplate("{{#if ok}}yes{{/if}}", { ok: "" })).toBe("");
+    expect(renderTemplate("{{#if ok}}yes{{/if}}", {})).toBe("");
+  });
+
+  it("treats an empty array as falsy", () => {
+    expect(renderTemplate("{{#if items}}has{{/if}}", { items: [] })).toBe("");
+    expect(renderTemplate("{{#if items}}has{{/if}}", { items: [1] })).toBe("has");
+  });
+
+  it("supports else", () => {
+    const tpl = "{{#if ok}}yes{{else}}no{{/if}}";
+    expect(renderTemplate(tpl, { ok: true })).toBe("yes");
+    expect(renderTemplate(tpl, { ok: false })).toBe("no");
+  });
+
+  it("nests", () => {
+    const tpl = "{{#if a}}A{{#if b}}B{{/if}}{{/if}}";
+    expect(renderTemplate(tpl, { a: true, b: true })).toBe("AB");
+    expect(renderTemplate(tpl, { a: true, b: false })).toBe("A");
+    expect(renderTemplate(tpl, { a: false, b: true })).toBe("");
+  });
+});
+
+describe("renderTemplate — #each", () => {
+  it("iterates primitives with {{this}}", () => {
+    expect(renderTemplate("{{#each xs}}[{{this}}]{{/each}}", { xs: ["a", "b"] })).toBe("[a][b]");
+  });
+
+  it("iterates objects with field access", () => {
+    const out = renderTemplate("{{#each rows}}<p>{{this.label}}:{{price}}</p>{{/each}}", {
+      rows: [{ label: "Tea", price: 20 }, { label: "Cake", price: 35 }],
+    });
+    expect(out).toBe("<p>Tea:20</p><p>Cake:35</p>");
+  });
+
+  it("exposes @index", () => {
+    expect(renderTemplate("{{#each xs}}{{@index}}{{/each}}", { xs: ["a", "b", "c"] })).toBe("012");
+  });
+
+  it("can still see the parent scope", () => {
+    const out = renderTemplate("{{#each xs}}{{currency}}{{this}} {{/each}}", {
+      currency: "₺",
+      xs: [10, 20],
+    });
+    expect(out).toBe("₺10 ₺20 ");
+  });
+
+  it("renders nothing when the value is not an array", () => {
+    expect(renderTemplate("{{#each xs}}x{{/each}}", { xs: "nope" })).toBe("");
+    expect(renderTemplate("{{#each xs}}x{{/each}}", {})).toBe("");
+  });
+
+  it("nests inside #if", () => {
+    const tpl = "{{#if rows}}<ul>{{#each rows}}<li>{{this}}</li>{{/each}}</ul>{{else}}empty{{/if}}";
+    expect(renderTemplate(tpl, { rows: ["a"] })).toBe("<ul><li>a</li></ul>");
+    expect(renderTemplate(tpl, { rows: [] })).toBe("empty");
+  });
+});
+
+describe("renderTemplate — robustness", () => {
+  it("never throws on an unbalanced block", () => {
+    expect(() => renderTemplate("{{#if a}}open", { a: true })).not.toThrow();
+    expect(renderTemplate("{{#if a}}open", { a: true })).toBe("open");
+  });
+
+  it("ignores a stray closing tag", () => {
+    expect(renderTemplate("a{{/if}}b", {})).toBe("ab");
+  });
+
+  it("keeps an unknown block keyword visible instead of swallowing it", () => {
+    expect(renderTemplate("{{#wat x}}body{{/wat}}", {})).toContain("{{#wat x}}");
+  });
+
+  it("returns an empty string for an empty template", () => {
+    expect(renderTemplate("", { a: 1 })).toBe("");
+  });
+
+  it("leaves markup without tags untouched", () => {
+    expect(renderTemplate("<p>plain</p>", {})).toBe("<p>plain</p>");
+  });
+});

--- a/packages/core/src/ui/defineGenUIComponent.ts
+++ b/packages/core/src/ui/defineGenUIComponent.ts
@@ -1,0 +1,126 @@
+import type { PropertyDeclaration } from "lit";
+import type { GenUIComponentDefinition } from "../domain/entities/GenUI";
+import { GenUIHtmlElement } from "./GenUIHtmlElement";
+import { renderTemplate } from "./template";
+
+/** Definition-derived classes, keyed by `name@version`, so a re-announced catalog reuses them. */
+const _defined = new Map<string, typeof GenUIHtmlElement>();
+
+/** `Order Card` → `order-card`; the result always contains a dash (custom elements require one). */
+function slugify(name: string): string {
+  const slug = name
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+  return slug || "component";
+}
+
+/** A tag nobody has claimed yet — a redefined component can't reuse its old tag. */
+function freeTag(preferred: string): string {
+  let tag = preferred;
+  let n = 1;
+  while (customElements.get(tag)) tag = `${preferred}-${n++}`;
+  return tag;
+}
+
+/** Attribute conversion follows the declared default, so plain-HTML usage works too. */
+function declarationFor(value: unknown): PropertyDeclaration {
+  if (typeof value === "number") return { type: Number };
+  if (typeof value === "boolean") return { type: Boolean };
+  if (value !== null && typeof value === "object") return { type: Object };
+  return { type: String };
+}
+
+/**
+ * Turn a server-supplied {@link GenUIComponentDefinition} into a registered
+ * custom element class.
+ *
+ * The returned class extends `GenUIHtmlElement`, so it inherits the sanitizer,
+ * the `data-event` round trip and the whole `GenUIComponentAPI` — it only swaps
+ * *where the markup comes from*: the definition's template, rendered against the
+ * component's declared props.
+ *
+ * Calling it twice with the same `name@version` returns the same class, so a
+ * reconnect that re-announces the catalog is a no-op instead of a leak of
+ * custom-element definitions.
+ *
+ * @example
+ * ```ts
+ * const OrderCard = defineGenUIComponent({
+ *   name: "order-card",
+ *   template: `<div class="card"><h3>{{title}}</h3>
+ *     {{#each lines}}<p>{{this.label}} — {{this.price}}</p>{{/each}}
+ *     <button data-event="track_order" data-payload='{"id":"{{id}}"}'>Track</button></div>`,
+ *   css: `.card { border: 1px solid #e2e8f0; border-radius: 12px; padding: 12px; }`,
+ *   props: { id: "", title: "", lines: [] },
+ * });
+ *
+ * GenUIRegistry.register("order-card", OrderCard);   // done for you by @chativa/genui
+ * ```
+ */
+export function defineGenUIComponent(
+  definition: GenUIComponentDefinition
+): typeof GenUIHtmlElement {
+  const key = `${definition.name}@${definition.version ?? "1"}`;
+  const cached = _defined.get(key);
+  if (cached) return cached;
+
+  const declaredProps = definition.props ?? {};
+  const propNames = Object.keys(declaredProps);
+
+  const properties: Record<string, PropertyDeclaration> = {};
+  for (const [name, value] of Object.entries(declaredProps)) {
+    // `html` / `css` / `unsafe` belong to the base element — a definition prop
+    // may not take them over, or a template could turn its own sanitizer off.
+    if (name === "html" || name === "css" || name === "unsafe") continue;
+    properties[name] = declarationFor(value);
+  }
+
+  class DefinedGenUIComponent extends GenUIHtmlElement {
+    static override properties = properties;
+
+    /** The metadata this class was built from — handy when debugging a catalog. */
+    static readonly definition: GenUIComponentDefinition = definition;
+
+    constructor() {
+      super();
+      // Defaults from the definition, so a chunk may send only what changed.
+      for (const name of propNames) {
+        if (name === "html" || name === "css" || name === "unsafe") continue;
+        (this as unknown as Record<string, unknown>)[name] = structuredCloneish(declaredProps[name]);
+      }
+      this.css = definition.css ?? "";
+    }
+
+    protected override markup(): string {
+      const scope: Record<string, unknown> = {};
+      for (const name of propNames) {
+        scope[name] = (this as unknown as Record<string, unknown>)[name];
+      }
+      return renderTemplate(definition.template, scope);
+    }
+  }
+
+  const tag = freeTag(definition.tag ?? `chativa-genui-${slugify(definition.name)}`);
+  customElements.define(tag, DefinedGenUIComponent);
+
+  _defined.set(key, DefinedGenUIComponent);
+  return DefinedGenUIComponent;
+}
+
+/** Defaults must not be shared between instances — an `each` list would alias. */
+function structuredCloneish(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(structuredCloneish);
+  if (value !== null && typeof value === "object") {
+    return Object.fromEntries(
+      Object.entries(value as Record<string, unknown>).map(([k, v]) => [k, structuredCloneish(v)])
+    );
+  }
+  return value;
+}
+
+/** Forget every derived class — tests only. */
+export function clearDefinedGenUIComponents(): void {
+  _defined.clear();
+}

--- a/packages/core/src/ui/template.ts
+++ b/packages/core/src/ui/template.ts
@@ -1,0 +1,171 @@
+/**
+ * The tiny template language backend-authored GenUI components are written in.
+ *
+ * A server-registered component ships markup, not code, so it needs just enough
+ * templating to be useful without becoming an expression evaluator on the
+ * client. Deliberately a strict subset — no arbitrary JS, no property calls, no
+ * filters:
+ *
+ * - `{{path.to.value}}` — HTML-escaped interpolation
+ * - `{{#if path}} … {{else}} … {{/if}}` — truthiness (empty string/array/0 is false)
+ * - `{{#each path}} … {{/each}}` — iteration, with `{{this}}`, `{{this.field}}`,
+ *   `{{@index}}`, and parent scope still reachable by name
+ *
+ * Everything is escaped, so a value can never inject markup; the output is then
+ * sanitized again by `<chativa-html>` before it reaches the DOM.
+ */
+
+/** Escape a value for safe use in both text and attribute positions. */
+export function escapeHtml(value: unknown): string {
+  if (value === null || value === undefined) return "";
+  return String(value)
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+}
+
+// ── AST ───────────────────────────────────────────────────────────────────────
+
+interface TextNode { kind: "text"; value: string }
+interface VarNode { kind: "var"; path: string }
+interface IfNode { kind: "if"; path: string; then: Node[]; else: Node[] }
+interface EachNode { kind: "each"; path: string; body: Node[] }
+type Node = TextNode | VarNode | IfNode | EachNode;
+
+/** Lexical scope chain — an `each` body can still see the props above it. */
+interface Scope {
+  data: unknown;
+  index?: number;
+  parent?: Scope;
+}
+
+const TAG = /\{\{\s*([#/]?)([^}]*?)\s*\}\}/g;
+
+function parse(template: string): Node[] {
+  const root: Node[] = [];
+  // Each frame is the list new nodes go into, plus what closes it.
+  const stack: { nodes: Node[]; block?: IfNode | EachNode }[] = [{ nodes: root }];
+  let last = 0;
+
+  const push = (node: Node) => stack[stack.length - 1]!.nodes.push(node);
+  const text = (value: string) => { if (value) push({ kind: "text", value }); };
+
+  TAG.lastIndex = 0;
+  let m: RegExpExecArray | null;
+  while ((m = TAG.exec(template)) !== null) {
+    text(template.slice(last, m.index));
+    last = m.index + m[0].length;
+
+    const sigil = m[1];
+    const body = m[2]!.trim();
+
+    if (sigil === "#") {
+      const [keyword, ...rest] = body.split(/\s+/);
+      const path = rest.join(" ").trim();
+      if (keyword === "if") {
+        const node: IfNode = { kind: "if", path, then: [], else: [] };
+        push(node);
+        stack.push({ nodes: node.then, block: node });
+      } else if (keyword === "each") {
+        const node: EachNode = { kind: "each", path, body: [] };
+        push(node);
+        stack.push({ nodes: node.body, block: node });
+      } else {
+        // Unknown block keyword: keep the literal so the mistake is visible
+        // in the rendered widget instead of silently vanishing.
+        text(m[0]);
+      }
+      continue;
+    }
+
+    if (sigil === "/") {
+      // Closing tag — only pop when there is a block to close, so a stray
+      // `{{/if}}` can't unwind past the root.
+      if (stack.length > 1) stack.pop();
+      continue;
+    }
+
+    if (body === "else") {
+      const frame = stack[stack.length - 1];
+      if (frame?.block?.kind === "if") {
+        stack[stack.length - 1] = { nodes: frame.block.else, block: frame.block };
+      }
+      continue;
+    }
+
+    push({ kind: "var", path: body });
+  }
+
+  text(template.slice(last));
+  return root;
+}
+
+/** Walk a dotted path from the innermost scope outwards. */
+function resolve(path: string, scope: Scope): unknown {
+  if (!path) return undefined;
+  if (path === "@index") {
+    for (let s: Scope | undefined = scope; s; s = s.parent) {
+      if (s.index !== undefined) return s.index;
+    }
+    return undefined;
+  }
+  if (path === "this" || path === ".") return scope.data;
+
+  const segments = path.replace(/^this\./, "").split(".");
+  for (let s: Scope | undefined = scope; s; s = s.parent) {
+    let current: unknown = s.data;
+    let ok = true;
+    for (const segment of segments) {
+      if (current === null || current === undefined || typeof current !== "object") { ok = false; break; }
+      if (!(segment in (current as Record<string, unknown>))) { ok = false; break; }
+      current = (current as Record<string, unknown>)[segment];
+    }
+    if (ok) return current;
+  }
+  return undefined;
+}
+
+function truthy(value: unknown): boolean {
+  if (Array.isArray(value)) return value.length > 0;
+  return Boolean(value);
+}
+
+function renderNodes(nodes: Node[], scope: Scope): string {
+  let out = "";
+  for (const node of nodes) {
+    switch (node.kind) {
+      case "text":
+        out += node.value;
+        break;
+      case "var":
+        out += escapeHtml(resolve(node.path, scope));
+        break;
+      case "if":
+        out += renderNodes(truthy(resolve(node.path, scope)) ? node.then : node.else, scope);
+        break;
+      case "each": {
+        const list = resolve(node.path, scope);
+        if (!Array.isArray(list)) break;
+        list.forEach((item, index) => {
+          out += renderNodes(node.body, { data: item, index, parent: scope });
+        });
+        break;
+      }
+    }
+  }
+  return out;
+}
+
+/**
+ * Render a component template against its props.
+ *
+ * Never throws: an unknown path renders as an empty string, an unbalanced block
+ * closes at the end of the template. A broken widget is a bad look; a crash
+ * inside a chat bubble is worse.
+ */
+export function renderTemplate(template: string, props: Record<string, unknown>): string {
+  if (!template) return "";
+  return renderNodes(parse(template), { data: props });
+}

--- a/packages/genui/src/components/GenUIMessage.ts
+++ b/packages/genui/src/components/GenUIMessage.ts
@@ -1,6 +1,13 @@
 import { html, css, nothing } from "lit";
 import { customElement, property } from "lit/decorators.js";
-import type { GenUIStreamState, AIChunk, AIChunkText, AIChunkUI, AIChunkEvent } from "@chativa/core";
+import type {
+  GenUIStreamState,
+  AIChunk,
+  AIChunkText,
+  AIChunkUI,
+  AIChunkEvent,
+  GenUIEventOptions,
+} from "@chativa/core";
 import { ChativaElement, MessageTypeRegistry, chatStore, i18next, t } from "@chativa/core";
 import { GenUIRegistry } from "../registry/GenUIRegistry";
 import { bubbleStyles } from "../styles/bubble";
@@ -176,7 +183,12 @@ export class GenUIMessage extends ChativaElement {
 
   // ── Event bus API (injected into child components) ────────────────────────
 
-  private _sendEvent = (type: string, payload: unknown, sourceId?: number): void => {
+  private _sendEvent = (
+    type: string,
+    payload: unknown,
+    sourceId?: number,
+    opts?: GenUIEventOptions
+  ): void => {
     // 1. Deliver to internal listeners within this message (e.g. form_success → form component)
     const listeners = this._listeners.get(type);
     if (listeners) {
@@ -189,7 +201,7 @@ export class GenUIMessage extends ChativaElement {
     // 2. Bubble up to ChatWidget so it can be forwarded to the connector
     this.dispatchEvent(
       new CustomEvent("genui-send-event", {
-        detail: { msgId: this.messageId, eventType: type, payload, sourceId },
+        detail: { msgId: this.messageId, eventType: type, payload, sourceId, ...opts },
         bubbles: true,
         composed: true,
       })
@@ -240,8 +252,15 @@ export class GenUIMessage extends ChativaElement {
       }
     }
 
-    // Retrieve or create the element instance
+    // Retrieve or create the element instance. A cached instance of a different
+    // class means the stream reused this id for another component — keep the id
+    // (so the element stays in place) but rebuild it, rather than assigning one
+    // component's props onto another's element.
     let el = this._instances.get(chunk.id);
+    if (el && !(el instanceof entry.component)) {
+      this._instances.delete(chunk.id);
+      el = undefined;
+    }
     if (!el) {
       el = new entry.component() as HTMLElement;
       this._instances.set(chunk.id, el);
@@ -249,8 +268,10 @@ export class GenUIMessage extends ChativaElement {
       // Inject scoped event + i18n API so custom components
       // don't need to depend on i18next directly.
       const elAny = el as unknown as Record<string, unknown>;
-      elAny["sendEvent"] = (type: string, payload: unknown) =>
-        this._sendEvent(type, payload, chunk.id);
+      // The component name is stamped here, not by the component: an interaction
+      // should always say which widget it came from, and only the chunk knows.
+      elAny["sendEvent"] = (type: string, payload: unknown, opts?: GenUIEventOptions) =>
+        this._sendEvent(type, payload, chunk.id, { component: chunk.component, ...opts });
       elAny["listenEvent"] = (type: string, cb: (p: unknown) => void) =>
         this._listenEvent(type, cb, chunk.id);
       elAny["tFn"] = (key: string, fallback?: string) =>

--- a/packages/genui/src/components/__tests__/GenUIHtmlChunk.test.ts
+++ b/packages/genui/src/components/__tests__/GenUIHtmlChunk.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect, vi } from "vitest";
+import type { GenUIStreamState } from "@chativa/core";
+import { GenUIHtmlElement } from "@chativa/core";
+import { GenUIRegistry } from "../../registry/GenUIRegistry";
+import "../../index";
+
+/**
+ * End-to-end path for backend-authored components: a connector streams a
+ * `{ type: "ui", component: "html" }` chunk, `GenUIMessage` mounts
+ * `<chativa-html>`, and a `data-event` click travels back out as
+ * `genui-send-event` (which ChatWidget forwards to
+ * `IConnector.receiveComponentEvent`).
+ */
+
+const streamState = (html: string): GenUIStreamState => ({
+  chunks: [{ type: "ui", component: "html", props: { html }, id: 1 }],
+  streamingComplete: true,
+});
+
+async function mountMessage(state: GenUIStreamState) {
+  const el = document.createElement("genui-message") as HTMLElement & {
+    messageData: unknown;
+    messageId: string;
+    updateComplete: Promise<boolean>;
+  };
+  el.messageId = "msg-1";
+  el.messageData = state;
+  document.body.appendChild(el);
+  await el.updateComplete;
+  return el;
+}
+
+const mountedHtmlElement = (msg: HTMLElement): GenUIHtmlElement =>
+  msg.shadowRoot!.querySelector("chativa-html") as GenUIHtmlElement;
+
+describe("backend-authored HTML chunk", () => {
+  it("registers the raw-markup component under both names", () => {
+    expect(GenUIRegistry.resolve("html")?.component).toBe(GenUIHtmlElement);
+    expect(GenUIRegistry.resolve("genui-html")?.component).toBe(GenUIHtmlElement);
+  });
+
+  it("mounts <chativa-html> and renders the streamed markup", async () => {
+    const msg = await mountMessage(streamState(`<p class="from-backend">Order #123</p>`));
+    const el = mountedHtmlElement(msg);
+
+    expect(el).not.toBeNull();
+    await el.updateComplete;
+    expect(el.shadowRoot!.innerHTML).toContain("Order #123");
+
+    msg.remove();
+  });
+
+  it("routes a data-event click back out as genui-send-event", async () => {
+    const msg = await mountMessage(
+      streamState(`<button data-event="track_order" data-payload='{"id":123}'>Track</button>`)
+    );
+    const el = mountedHtmlElement(msg);
+    await el.updateComplete;
+
+    const spy = vi.fn();
+    document.body.addEventListener("genui-send-event", spy as EventListener);
+    el.shadowRoot!.querySelector("button")!.click();
+
+    expect(spy).toHaveBeenCalledOnce();
+    const detail = (spy.mock.calls[0]![0] as CustomEvent).detail;
+    expect(detail).toMatchObject({
+      msgId: "msg-1",
+      eventType: "track_order",
+      payload: { id: 123 },
+      sourceId: 1,
+    });
+
+    document.body.removeEventListener("genui-send-event", spy as EventListener);
+    msg.remove();
+  });
+
+  it("updates the same instance when the backend streams new markup", async () => {
+    const msg = await mountMessage(streamState("<p>step one</p>")) as HTMLElement & {
+      messageData: unknown;
+      updateComplete: Promise<boolean>;
+    };
+    const first = mountedHtmlElement(msg);
+
+    msg.messageData = streamState("<p>step two</p>");
+    await msg.updateComplete;
+    const second = mountedHtmlElement(msg);
+    await second.updateComplete;
+
+    // Same element instance (keyed by chunk id), new content.
+    expect(second).toBe(first);
+    expect(second.shadowRoot!.innerHTML).toContain("step two");
+    expect(second.shadowRoot!.innerHTML).not.toContain("step one");
+
+    msg.remove();
+  });
+});

--- a/packages/genui/src/index.ts
+++ b/packages/genui/src/index.ts
@@ -6,9 +6,25 @@ import "./i18n/index";
 // ── Registry ──────────────────────────────────────────────────────────────────
 export { GenUIRegistry } from "./registry/GenUIRegistry";
 export type { GenUIEntry, GenUISchema } from "./registry/GenUIRegistry";
+export {
+  registerServerComponent,
+  subscribeServerComponents,
+  clearServerComponents,
+  setServerComponentPolicy,
+  getServerComponentPolicy,
+} from "./registry/serverComponents";
+export type { ServerComponentPolicy } from "./registry/serverComponents";
 
 // ── Shared types ──────────────────────────────────────────────────────────────
 export type { GenUIComponentAPI } from "./types";
+
+// ── Base class for custom components ──────────────────────────────────────────
+// Lives in @chativa/core (so core owns the contract); re-exported here so a
+// custom component only needs one import.
+export { GenUIElement, GENUI_COMPONENT_EVENT } from "@chativa/core";
+export type { GenUIComponentEventDetail } from "@chativa/core";
+export { GenUIHtmlElement, sanitizeHtml, defineGenUIComponent, renderTemplate, genUIDefinitionStore } from "@chativa/core";
+export type { GenUIComponentDefinition } from "@chativa/core";
 
 // ── Components (side-effects: registers custom elements) ──────────────────────
 export { GenUIMessage } from "./components/GenUIMessage";
@@ -56,6 +72,8 @@ export type {
 // ── Register built-in components in GenUIRegistry ─────────────────────────────
 // These are available out-of-the-box without any additional registration.
 import { GenUIRegistry } from "./registry/GenUIRegistry";
+import { GenUIHtmlElement } from "@chativa/core";
+import { subscribeServerComponents } from "./registry/serverComponents";
 import { GenUITextBlock } from "./components/GenUITextBlock";
 import { GenUICard } from "./components/GenUICard";
 import { GenUIForm } from "./components/GenUIForm";
@@ -83,3 +101,14 @@ GenUIRegistry.register("genui-date-picker",   GenUIDatePicker as unknown as type
 GenUIRegistry.register("genui-chart",         GenUIChart as unknown as typeof HTMLElement);
 GenUIRegistry.register("genui-steps",         GenUISteps as unknown as typeof HTMLElement);
 GenUIRegistry.register("genui-image-gallery", GenUIImageGallery as unknown as typeof HTMLElement);
+
+// Raw-markup escape hatch: the backend ships the HTML itself, no client build
+// step. Registered under both names — `html` is what most bots will send.
+GenUIRegistry.register("genui-html",          GenUIHtmlElement as unknown as typeof HTMLElement);
+GenUIRegistry.register("html",                GenUIHtmlElement as unknown as typeof HTMLElement);
+
+// ── Server-defined components ─────────────────────────────────────────────────
+// A backend that authors its own components announces them on connect; this
+// subscription turns each definition into a custom element and registers it.
+// Replays anything published before this bundle loaded.
+subscribeServerComponents();

--- a/packages/genui/src/registry/__tests__/serverComponents.test.ts
+++ b/packages/genui/src/registry/__tests__/serverComponents.test.ts
@@ -1,0 +1,143 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { genUIDefinitionStore, clearDefinedGenUIComponents, type GenUIComponentDefinition } from "@chativa/core";
+import { GenUIRegistry } from "../GenUIRegistry";
+import {
+  registerServerComponent,
+  subscribeServerComponents,
+  clearServerComponents,
+  setServerComponentPolicy,
+  getServerComponentPolicy,
+} from "../serverComponents";
+import "../../index";
+
+const CARD: GenUIComponentDefinition = {
+  name: "order-card",
+  template: `<div><h3>{{title}}</h3><button data-event="track">Track</button></div>`,
+  props: { title: "" },
+};
+
+beforeEach(() => {
+  clearServerComponents();
+  clearDefinedGenUIComponents();
+  genUIDefinitionStore.clear();
+});
+
+afterEach(() => vi.restoreAllMocks());
+
+describe("registerServerComponent", () => {
+  it("registers a definition under its name", () => {
+    expect(registerServerComponent(CARD)).toBe(true);
+    expect(GenUIRegistry.has("order-card")).toBe(true);
+  });
+
+  it("produces a constructible element that renders the template", async () => {
+    registerServerComponent(CARD);
+    const Ctor = GenUIRegistry.resolve("order-card")!.component;
+
+    const el = new Ctor() as HTMLElement & { title: string; updateComplete: Promise<boolean> };
+    el.title = "Order #7";
+    document.body.appendChild(el);
+    await el.updateComplete;
+
+    expect(el.shadowRoot!.innerHTML).toContain("Order #7");
+    el.remove();
+  });
+
+  it("rejects a definition without a name or template", () => {
+    expect(registerServerComponent({ name: "", template: "<p>x</p>" })).toBe(false);
+    expect(registerServerComponent({ name: "x" } as GenUIComponentDefinition)).toBe(false);
+  });
+
+  it("refuses to overwrite a built-in", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const before = GenUIRegistry.resolve("genui-form")!.component;
+
+    expect(registerServerComponent({ name: "genui-form", template: "<p>hijacked</p>" })).toBe(false);
+    expect(GenUIRegistry.resolve("genui-form")!.component).toBe(before);
+    expect(warn).toHaveBeenCalled();
+  });
+
+  it("lets the server replace a component it defined itself", () => {
+    registerServerComponent(CARD);
+    const first = GenUIRegistry.resolve("order-card")!.component;
+
+    expect(registerServerComponent({ ...CARD, version: "2", template: "<p>v2</p>" })).toBe(true);
+    expect(GenUIRegistry.resolve("order-card")!.component).not.toBe(first);
+  });
+});
+
+describe("subscribeServerComponents", () => {
+  it("registers definitions published to the store", () => {
+    const unsub = subscribeServerComponents();
+    genUIDefinitionStore.publish([CARD]);
+
+    expect(GenUIRegistry.has("order-card")).toBe(true);
+    unsub();
+  });
+
+  it("picks up definitions published before it subscribed", () => {
+    genUIDefinitionStore.publish([CARD]);
+    const unsub = subscribeServerComponents();
+
+    expect(GenUIRegistry.has("order-card")).toBe(true);
+    unsub();
+  });
+
+  it("stops registering after unsubscribe", () => {
+    subscribeServerComponents()();
+    genUIDefinitionStore.publish([CARD]);
+
+    expect(GenUIRegistry.has("order-card")).toBe(false);
+  });
+});
+
+describe("name collisions with a locally registered component", () => {
+  /** What the sandbox does: register a component under a name the server also uses. */
+  const registerLocal = (name: string) =>
+    GenUIRegistry.register(name, class extends HTMLElement {} as unknown as typeof HTMLElement);
+
+  it("defaults to app-wins", () => {
+    expect(getServerComponentPolicy()).toBe("app-wins");
+  });
+
+  it("keeps the local component and says why", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    registerLocal("order-card");
+    const local = GenUIRegistry.resolve("order-card")!.component;
+
+    expect(registerServerComponent({ ...CARD, name: "order-card" })).toBe(false);
+    expect(GenUIRegistry.resolve("order-card")!.component).toBe(local);
+    // The blank-widget failure mode is only debuggable if the warning names the
+    // component and the way out.
+    const message = String(warn.mock.calls[0]![0]);
+    expect(message).toContain("order-card");
+    expect(message).toContain("server-wins");
+
+    GenUIRegistry.unregister("order-card");
+  });
+
+  it("lets the server win when the policy says so", () => {
+    registerLocal("order-card");
+    const local = GenUIRegistry.resolve("order-card")!.component;
+    setServerComponentPolicy("server-wins");
+
+    expect(registerServerComponent({ ...CARD, name: "order-card" })).toBe(true);
+    expect(GenUIRegistry.resolve("order-card")!.component).not.toBe(local);
+
+    GenUIRegistry.unregister("order-card");
+  });
+
+  it("still refuses to clobber a built-in under app-wins", () => {
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+    const before = GenUIRegistry.resolve("genui-form")!.component;
+
+    expect(registerServerComponent({ name: "genui-form", template: "<p>x</p>" })).toBe(false);
+    expect(GenUIRegistry.resolve("genui-form")!.component).toBe(before);
+  });
+
+  it("clearServerComponents resets the policy", () => {
+    setServerComponentPolicy("server-wins");
+    clearServerComponents();
+    expect(getServerComponentPolicy()).toBe("app-wins");
+  });
+});

--- a/packages/genui/src/registry/serverComponents.ts
+++ b/packages/genui/src/registry/serverComponents.ts
@@ -1,0 +1,97 @@
+import {
+  defineGenUIComponent,
+  genUIDefinitionStore,
+  type GenUIComponentDefinition,
+} from "@chativa/core";
+import { GenUIRegistry } from "./GenUIRegistry";
+
+/** Names that came from the server, so a catalog can replace its own earlier version. */
+const _fromServer = new Set<string>();
+
+/**
+ * Who wins when a server definition names a component the app already registered.
+ *
+ * - `"app-wins"` (default) — the local component stays. A backend must not be
+ *   able to redefine `genui-form`, or the checkout widget you shipped, under
+ *   your feet.
+ * - `"server-wins"` — the definition replaces the local registration. Choose
+ *   this when the server is the source of truth for widgets and the local
+ *   registrations are only fallbacks.
+ */
+export type ServerComponentPolicy = "app-wins" | "server-wins";
+
+let _policy: ServerComponentPolicy = "app-wins";
+
+/**
+ * Decide what happens on a name collision. Call before connecting.
+ *
+ * @example
+ * ```ts
+ * import { setServerComponentPolicy } from "@chativa/genui";
+ *
+ * setServerComponentPolicy("server-wins");
+ * ```
+ */
+export function setServerComponentPolicy(policy: ServerComponentPolicy): void {
+  _policy = policy;
+}
+
+/** The policy in force. */
+export function getServerComponentPolicy(): ServerComponentPolicy {
+  return _policy;
+}
+
+/**
+ * Register one server-defined component.
+ *
+ * A definition always replaces an earlier definition of the same name from the
+ * server itself (a new version of the same widget). A collision with a *local*
+ * registration is resolved by {@link setServerComponentPolicy}.
+ *
+ * @returns whether the component was registered.
+ */
+export function registerServerComponent(definition: GenUIComponentDefinition): boolean {
+  const { name } = definition;
+  if (!name || typeof definition.template !== "string") return false;
+
+  const collidesWithLocal = GenUIRegistry.has(name) && !_fromServer.has(name);
+  if (collidesWithLocal && _policy === "app-wins") {
+    // Silence here is the worst outcome: the local component renders with the
+    // server's props, which it was never written for, and the widget comes out
+    // blank. Say exactly what happened and what the two ways out are.
+    console.warn(
+      `[GenUI] The server defines a component named "${name}", but "${name}" is already ` +
+        `registered locally — keeping the local one (policy: "app-wins").\n` +
+        `  • the widget will render with the SERVER's props, which the local component may not expect\n` +
+        `  • to let the server win:  setServerComponentPolicy("server-wins")\n` +
+        `  • or rename one of them so both can coexist.`
+    );
+    return false;
+  }
+
+  GenUIRegistry.register(name, defineGenUIComponent(definition) as unknown as typeof HTMLElement);
+  _fromServer.add(name);
+  return true;
+}
+
+/**
+ * Subscribe the registry to server-announced component catalogs.
+ *
+ * Called once as a side-effect of importing `@chativa/genui`. Subscribing
+ * replays whatever the connector already published, so it doesn't matter
+ * whether the socket connected before or after this bundle loaded.
+ *
+ * @returns an unsubscribe function (tests; apps never need it).
+ */
+export function subscribeServerComponents(): () => void {
+  return genUIDefinitionStore.subscribe((definitions) => {
+    for (const definition of definitions) registerServerComponent(definition);
+  });
+}
+
+/** Forget which names came from the server, and reset the policy — tests only. */
+export function clearServerComponents(): void {
+  for (const name of _fromServer) GenUIRegistry.unregister(name);
+  _fromServer.clear();
+  _policy = "app-wins";
+}

--- a/packages/genui/src/types.ts
+++ b/packages/genui/src/types.ts
@@ -1,34 +1,17 @@
 /**
- * API injected by `GenUIMessage` into every registered custom component instance.
+ * The GenUI component contract now lives in `@chativa/core` next to the
+ * `GenUIElement` base class that implements it. Re-exported here so existing
+ * `import type { GenUIComponentAPI } from "@chativa/genui"` keeps working.
  *
- * Use this interface in your custom components to type the injected properties:
+ * Prefer extending `GenUIElement` — it implements the whole API with working
+ * defaults, so you don't declare the injected properties yourself:
  *
  * ```ts
- * import type { GenUIComponentAPI } from "@chativa/genui";
+ * import { GenUIElement } from "@chativa/core";
  *
- * class MyWidget extends LitElement implements Partial<GenUIComponentAPI> {
- *   sendEvent?: GenUIComponentAPI["sendEvent"];
- *   listenEvent?: GenUIComponentAPI["listenEvent"];
- *   tFn?: GenUIComponentAPI["tFn"];
- *   onLangChange?: GenUIComponentAPI["onLangChange"];
+ * class MyWidget extends GenUIElement {
+ *   private _submit() { this.sendEvent("my_submit", { ok: true }); }
  * }
  * ```
  */
-export interface GenUIComponentAPI {
-  /** Send an event to the connector (e.g. `"form_submit"`, `"rating_submit"`). */
-  sendEvent(type: string, payload: unknown): void;
-  /** Listen for a server-originated event within this message scope. */
-  listenEvent(type: string, cb: (payload: unknown) => void): void;
-  /**
-   * Translate a key using the shared i18next instance.
-   * Falls back to `fallback` if the key is not found.
-   * Named `tFn` (not `translate`) to avoid conflict with the native
-   * `HTMLElement.translate` boolean attribute.
-   */
-  tFn(key: string, fallback?: string): string;
-  /**
-   * Subscribe to locale changes so you can call `requestUpdate()`.
-   * Returns an unsubscribe function — call it in `disconnectedCallback`.
-   */
-  onLangChange(cb: () => void): () => void;
-}
+export type { GenUIComponentAPI } from "@chativa/core";

--- a/packages/ui/src/chat-ui/AgentPanel.ts
+++ b/packages/ui/src/chat-ui/AgentPanel.ts
@@ -6,6 +6,7 @@ import {
   messageStore,
   conversationStore,
   createOutgoingMessage,
+  type GenUIEventOptions,
 } from "@chativa/core";
 import { registerCommand } from "../commands/index";
 import "./ConversationList";
@@ -219,13 +220,10 @@ export class AgentPanel extends LitElement {
   };
 
   private _onGenUISendEvent = (
-    e: CustomEvent<{ msgId: string; eventType: string; payload: unknown }>
+    e: CustomEvent<{ msgId: string; eventType: string; payload: unknown } & GenUIEventOptions>
   ) => {
-    this._engine.chatEngine.receiveComponentEvent(
-      e.detail.msgId,
-      e.detail.eventType,
-      e.detail.payload
-    );
+    const { msgId, eventType, payload, scope, component } = e.detail;
+    this._engine.chatEngine.receiveComponentEvent(msgId, eventType, payload, { scope, component });
   };
 
   // ── Render ────────────────────────────────────────────────────────────

--- a/packages/ui/src/chat-ui/ChatWidget.ts
+++ b/packages/ui/src/chat-ui/ChatWidget.ts
@@ -11,6 +11,7 @@ import {
   createOutgoingMessage,
   applyGlobalSettings,
   type EndOfConversationSurveyConfig,
+  type GenUIEventOptions,
   type SurveyPayload,
 } from "@chativa/core";
 import { ChatbotMixin } from "../mixins/ChatbotMixin";
@@ -465,8 +466,11 @@ export class ChatWidget extends ChatbotMixin(LitElement) {
       .catch((err: unknown) => console.error("[ChatWidget] loadHistory failed:", err));
   };
 
-  private _onGenUISendEvent = (e: CustomEvent<{ msgId: string; eventType: string; payload: unknown }>) => {
-    this._engine.receiveComponentEvent(e.detail.msgId, e.detail.eventType, e.detail.payload);
+  private _onGenUISendEvent = (
+    e: CustomEvent<{ msgId: string; eventType: string; payload: unknown } & GenUIEventOptions>
+  ) => {
+    const { msgId, eventType, payload, scope, component } = e.detail;
+    this._engine.receiveComponentEvent(msgId, eventType, payload, { scope, component });
   };
 
   // ── Multi-conversation handlers ───────────────────────────────────────

--- a/website/docs/genui/built-in.md
+++ b/website/docs/genui/built-in.md
@@ -24,6 +24,7 @@ Auto-registered by importing `@chativa/genui`.
 | `genui-steps` | Vertical step list | `steps: { label, status, description? }[]` | — |
 | `genui-image-gallery` | Grid of images | `columns?, images: { src, alt?, caption? }[]` | — |
 | `genui-appointment-form` | Specialised appointment form | `fields[]` | `form_submit` |
+| `genui-html` / `html` | Backend-authored raw markup ([details](./custom-component.md)) | `html: string, css?: string, unsafe?: boolean` | any `data-event` on a clicked element or submitted `<form>` |
 
 ## Visual reference
 

--- a/website/docs/genui/custom-component.md
+++ b/website/docs/genui/custom-component.md
@@ -1,93 +1,303 @@
 ---
 sidebar_position: 4
 title: Custom component
-description: Build your own GenUI component — the GenUIComponentAPI injection (sendEvent, listenEvent, tFn, onLangChange).
+description: Build your own GenUI component — extend GenUIElement, or stream raw markup from the backend with <chativa-html>.
 ---
 
 # Custom GenUI component
 
-Anything you can build as a LitElement can be a GenUI component. Register it once; bots can stream it forever.
+Two ways to get your own UI into a chat bubble:
+
+| | Use when |
+|---|---|
+| **Extend `GenUIElement`** | You ship a compiled widget with the frontend. Full LitElement power, typed props. |
+| **Stream `<chativa-html>`** | The markup comes from the backend, a CMS, or a React app. No client-side build step, no redeploy to add a widget. |
+| **Let the server define it** (mekik) | The backend owns the whole widget and announces it on connect. Adding a widget is a server deploy. |
+
+Both live in `@chativa/core`, so a widget package doesn't have to depend on `@chativa/genui`.
+
+## 1. Extend `GenUIElement`
+
+`GenUIElement` extends `ChativaElement` (i18n + auto re-render on locale switch) and implements the whole `GenUIComponentAPI` with working defaults. You call `this.sendEvent(...)` / `this.listenEvent(...)` / `this.tFn(...)` directly — no optional chaining, no injected-property boilerplate.
 
 ```ts
-import { LitElement, html, css } from "lit";
+import { GenUIElement } from "@chativa/core";
+import { GenUIRegistry } from "@chativa/genui";
+import { html, css } from "lit";
 import { customElement, property } from "lit/decorators.js";
-import { GenUIRegistry, type GenUIComponentAPI } from "@chativa/genui";
 
 @customElement("weather-widget")
-export class WeatherWidget extends LitElement {
-  // Injected by GenUIMessage at mount time:
-  sendEvent?: GenUIComponentAPI["sendEvent"];
-  listenEvent?: GenUIComponentAPI["listenEvent"];
-  tFn?: GenUIComponentAPI["tFn"];
-  onLangChange?: GenUIComponentAPI["onLangChange"];
-
-  @property({ type: String })  city = "";
-  @property({ type: Number })  temp = 0;
-  @property({ type: String })  condition = "";
-
-  private _unsubLang?: () => void;
-
-  connectedCallback() {
-    super.connectedCallback();
-    // Re-render on locale switch so tFn returns the new language
-    this._unsubLang = this.onLangChange?.(() => this.requestUpdate());
-  }
-
-  disconnectedCallback() {
-    super.disconnectedCallback();
-    this._unsubLang?.();
-  }
-
-  static styles = css`
+export class WeatherWidget extends GenUIElement {
+  static override styles = css`
     :host { display: block; }
-    .card {
-      border: 1px solid var(--chativa-border-color);
-      border-radius: 12px; padding: 12px;
-    }
+    .card { border: 1px solid var(--chativa-border-color); border-radius: 12px; padding: 12px; }
   `;
 
-  private _refresh() {
-    // Echo back to the connector — connector receives this via receiveComponentEvent
-    this.sendEvent?.("refresh_weather", { city: this.city });
+  @property({ type: String }) city = "";
+  @property({ type: Number }) temp = 0;
+
+  override connectedCallback() {
+    super.connectedCallback();
+    // Server-pushed event chunks targeting this component
+    this.listenEvent("weather_updated", (p) => {
+      this.temp = (p as { temp: number }).temp;
+    });
   }
 
-  render() {
-    const refresh = this.tFn?.("widget.refresh", "Refresh") ?? "Refresh";
+  override render() {
     return html`
       <div class="card">
         <h3>${this.city}</h3>
-        <p>${this.temp}°C · ${this.condition}</p>
-        <button @click=${this._refresh}>${refresh}</button>
+        <p>${this.temp}°C</p>
+        <button @click=${() => this.sendEvent("refresh_weather", { city: this.city })}>
+          ${this.tFn("widget.refresh", "Refresh")}
+        </button>
       </div>
     `;
   }
 }
 
-// Side-effect register
 GenUIRegistry.register("weather", WeatherWidget);
 ```
 
-Then a connector can stream it as `{ type: "ui", component: "weather", props: { city, temp, condition } }`.
+The connector then streams `{ type: "ui", component: "weather", props: { city, temp } }`.
+
+**Don't redeclare** `sendEvent` / `listenEvent` / `tFn` / `onLangChange` as class fields — that shadows the base implementations with `undefined`. The old pattern (extending `LitElement` and declaring the four optional fields) still works; it's just boilerplate you no longer need.
+
+## 2. Stream raw markup with `<chativa-html>`
+
+Registered out of the box under `genui-html` and `html`, so a backend can ship the markup itself:
+
+```json
+{
+  "type": "ui",
+  "component": "html",
+  "props": {
+    "html": "<div class='card'><h3>Order #123</h3><button data-event='track_order' data-payload='{\"id\":123}'>Track</button></div>",
+    "css": ".card { border: 1px solid #e2e8f0; border-radius: 12px; padding: 12px; }"
+  }
+}
+```
+
+The click reaches your connector as `receiveComponentEvent(streamId, "track_order", { id: 123 })` — the same round trip a compiled component gets.
+
+### Props
+
+| Prop | Meaning |
+|---|---|
+| `html` | Markup to render. Sanitized unless `unsafe` is set. When empty, light-DOM children are rendered instead. |
+| `css` | CSS injected into the element's shadow root — scoped, so it can't leak into the page. |
+| `unsafe` | Skip sanitization. Only for markup you fully control. |
+
+### Interaction contract
+
+A click — or a form submit — on an element carrying an event attribute sends that
+event. Which attribute you use says **who the interaction is addressed to**, for
+backends that model the distinction (mekik `PROTOCOL.md` §10.4):
+
+| attribute | `scope` sent | meaning |
+| --- | --- | --- |
+| `component-event="<name>"` | `"component"` | the widget's own conversation with the graph node that mounted it — only a node waiting for that event name receives it |
+| `mekik-event="<name>"` | `"graph"` | the application, which may start a new turn on it |
+| `data-event="<name>"` | none | let the backend decide (the original form, unchanged) |
+
+Only the most specific attribute on an element is used, in the order above; an
+empty value is not a trigger. Backends that don't model routing ignore `scope`, so
+`data-event` keeps behaving exactly as it did.
+
+- `data-payload='<json>'` → parsed and sent as the payload; invalid JSON is sent as the raw string.
+- `<form component-event="...">` (or `mekik-event` / `data-event`) → the submit is intercepted and the named fields are sent, merged over `data-payload`.
+
+The frame that reaches the backend also carries `component` — the registry name of
+the widget the interaction came from. `GenUIMessage` fills that in from the chunk,
+so a component never sets it itself.
+
+### Safety
+
+Markup is sanitized by default: `<script>`, `<iframe>`, `<object>`, `<link>`, `<meta>` and friends are dropped, every `on*` attribute is stripped, and absolute URLs must use a trusted scheme (`http(s):`, `mailto:`, `tel:`, `sms:`, `ftp:`, or `data:image/`) — relative URLs pass through untouched, and obfuscated variants (embedded tabs or newlines, mixed case) are normalised before the check. Structure, classes and inline styles survive untouched. The sanitizer is exported as `sanitizeHtml(markup)` if you want to run it earlier in your pipeline.
+
+Setting `unsafe` re-enables `<script>` and inline handlers — only do that for markup you generate yourself, never for text an LLM or an end user can influence.
+
+### Outside a chat message
+
+`<chativa-html>` is a plain custom element, so it works anywhere:
+
+```html
+<!-- Markup as children -->
+<chativa-html>
+  <button data-event="say_hi">Hi</button>
+</chativa-html>
+```
+
+```tsx
+// React
+<chativa-html ref={(el) => { if (el) el.html = markup; }} />
+```
+
+When no host has injected `sendEvent` — i.e. the element isn't inside a `GenUIMessage` — events are dispatched as a bubbling, composed `genui-component-event` DOM event with `detail: { eventType, payload }`, so the page can still react.
+
+## 3. Let the backend define the component (mekik)
+
+The two options above still need the markup to reach the page somehow. A mekik
+backend can skip that: it defines the component itself and announces the catalog
+on connect, so a `{ type: "ui", component: "order-card" }` chunk mounts a widget
+nobody compiled into the client.
+
+```ts
+// mekik server
+const orderCard = defineComponent({
+  name: "order-card",
+  template: `<h3>{{title}}</h3>
+    {{#each lines}}<p>{{this.label}} — {{this.price}} ₺</p>{{/each}}
+    <button mekik-event="track_order" data-payload='{"id":"{{id}}"}'>Track</button>`,
+  css: `h3 { margin: 0 0 8px; }`,
+  props: { id: "", title: "", lines: [] },
+});
+
+const app = mekik({ graph, components: [orderCard] });
+```
+
+Nothing to do on the client: `@chativa/genui` subscribes to the catalog at import
+time, turns each definition into a custom element (via `defineGenUIComponent`) and
+registers it under its name.
+
+### What travels, and when
+
+```
+hello  { componentsHash?: "<cached>" }        ← the widget already sends this frame
+welcome
+genui_components  { hash, components: [...] }  ← only when the hash moved
+                  { hash, unchanged: true }    ← otherwise: no markup
+```
+
+The catalog is cached in `localStorage` under the server URL, so a returning user's
+widgets render before the server answers, and validating the cache costs no extra
+round trip — the hash rides along on the `hello` frame the connector already sends.
+Change a template on the server and the hash changes; the next connect picks it up.
+
+### Template language
+
+| form | meaning |
+|---|---|
+| `{{path.to.value}}` | HTML-escaped interpolation |
+| `{{#if path}} … {{else}} … {{/if}}` | truthiness (empty string / empty array / 0 are false) |
+| `{{#each path}} … {{/each}}` | iteration, with `{{this}}`, `{{this.field}}`, `{{@index}}`, parent scope still visible |
+
+Interactions use the same event-attribute contract as `<chativa-html>`, and arrive
+at the connector as `receiveComponentEvent` — a server-defined component gets the
+same round trip a compiled one does.
+
+With a mekik backend the choice of attribute is what routes the click: a
+`mekik-event` reaches the app's `onGenUiEvent` handler and can start a new turn,
+while a `component-event` reaches only a graph node parked on `mekik.onEvent`
+waiting for that name — so a widget can answer the very run that mounted it. A
+pause waiting that way announces `data.event` on its `interrupt` frame, and the
+connector renders no chat chips for it: the widget on screen is the answer.
+
+### Driving a server-defined component
+
+A definition is markup; what makes it feel alive is the chunk stream. Two moves
+cover almost everything:
+
+**Re-render it.** Send the same `id` again with new props and the element updates
+in place — see [Updating a component in place](./streaming.md#updating-a-component-in-place).
+
+```ts
+// mekik server — one card, walked through its states
+await phase(ctx, "packing",    () => orderCard(ctx, props("Preparing"),  { id: "card-1" }));
+await phase(ctx, "in_transit", () => orderCard(ctx, props("In transit"), { id: "card-1" }));
+```
+
+**Let a human change it.** The run can pause on chips while the widget stays on
+screen, and the answer re-renders that same element:
+
+```ts
+const choice = await mekik.choose(ctx, "What should the courier do?", [
+    mekik.action("Hand it to me", "handover"),
+    mekik.action("Reschedule", "reschedule"),
+] as const);
+
+orderCard(ctx, props(choice === "handover" ? "Delivered" : "Rescheduled"), { id: "card-1" });
+```
+
+Two things to get right on the server side:
+
+- **Pace the updates.** Emissions that land together are invisible; the client
+  renders the final state and nothing looks like it moved.
+- **Wrap pre-pause emissions in `ctx.step`** (`ctx.StepAsync` in .NET) and use
+  literal chunk ids. A resume replays the node from the top: without the journal
+  the whole sequence is re-sent and the widget flashes back through states the
+  user already saw; with it, only what follows the answer travels.
+
+Runnable end to end: [`ts/examples/server-components.ts`](https://github.com/AimTune/mekik/blob/main/ts/examples/server-components.ts)
+and `dotnet/examples/Mekik.ServerComponents` in the mekik repo.
+
+### Limits
+
+### Name collisions
+
+A server definition never silently replaces a component the page already
+registered — a backend must not be able to redefine `genui-form`, or your own
+checkout widget, under your feet. The collision is logged and the local
+component stays.
+
+That default has a sharp edge worth knowing: the local component then renders
+with the *server's* props, which it was never written for, so the widget usually
+comes out blank. If a server-defined widget renders empty, check the console for
+the collision warning first.
+
+Two ways out:
+
+```ts
+import { setServerComponentPolicy } from "@chativa/genui";
+
+// the server is the source of truth for widgets
+setServerComponentPolicy("server-wins");
+```
+
+…or rename one of the two so both can coexist. A definition always replaces an
+earlier definition of the same name *from the server itself* — that is a new
+version of the same widget, not a collision.
+
+### Other limits
+
+- `unsafe` is not honoured from the wire. Server markup is always sanitized.
+- Only `@chativa/connector-mekik` implements the catalog handshake. Other
+  connectors ignore the frame.
+
+## Backend-driven components end to end
+
+With a streaming connector (Mekik, SSE, WebSocket, SignalR), the backend owns the whole widget:
+
+```
+backend frame  { type: "genui", streamId, chunk: { type: "ui", component: "html", props: { html, css } }, done }
+      ↓ connector.onGenUIChunk
+GenUIMessage mounts <chativa-html> and syncs props on every chunk
+      ↓ user clicks [component-event | mekik-event | data-event]
+connector.receiveComponentEvent(streamId, eventType, payload, { scope, component })
+      ↓ e.g. Mekik sends { type: "genui_event", streamId, eventType, scope, component, payload }
+backend
+```
+
+Because props are re-assigned on every chunk, re-sending the same chunk id with new `html` updates the widget in place — that's how you stream a form into its own success state.
 
 ## The injected API
 
-`GenUIMessage` injects four methods at mount time:
+`GenUIMessage` assigns four methods onto each mounted instance, shadowing `GenUIElement`'s defaults:
 
 | Method | Purpose |
 |---|---|
-| `sendEvent(type, payload)` | Send to the connector via `IConnector.receiveComponentEvent`. |
+| `sendEvent(type, payload, opts?)` | Send to the connector via `IConnector.receiveComponentEvent`. `opts` is routing metadata — `{ scope }` says who the interaction is addressed to (see the table above); `component` is stamped in by `GenUIMessage`, never by the component. |
 | `listenEvent(type, cb)` | Subscribe to event chunks targeting this component (`for === this.id`) or broadcast events. |
 | `tFn(key, fallback?)` | i18next translation. |
 | `onLangChange(cb)` | Subscribe to locale changes. Returns an unsubscribe function. |
+
+Outside a message the defaults keep working: `sendEvent` dispatches `genui-component-event`, `listenEvent` registers locally (deliver with `receiveEvent(type, payload)` in tests), and `tFn` / `onLangChange` use the shared i18next instance.
 
 ## Naming convention
 
 - Built-in components are namespaced `genui-<thing>` (kebab-case). For your own widgets, any unique custom-element-compatible name works; just stay consistent across registrations.
 - Don't expose a `translate` property on your component — `HTMLElement.translate` collides. Always use `tFn`.
-
-## Don't extend ChatbotMixin
-
-GenUI components are standalone — they don't share the chat widget's mixin chain. They get the i18n hook via the `tFn` injection, not via `I18nMixin`.
 
 ## Tip — use the scaffolder
 

--- a/website/docs/genui/streaming.md
+++ b/website/docs/genui/streaming.md
@@ -1,9 +1,4 @@
 ---
-sidebar_position: 2
-title: Streaming protocol
-description: AIChunk — text, ui, event chunks. How connectors emit streams and how component events round-trip back.
----
-
 # GenUI streaming protocol
 
 A connector advertises GenUI support by implementing `onGenUIChunk(callback)`. The engine then renders any chunks the connector emits as a single synthetic `genui` message.
@@ -22,8 +17,68 @@ Schema: [`schemas/genui/ai-chunk.schema.json`](https://github.com/AimTune/chativ
 | Chunk | Behaviour |
 |---|---|
 | `text` | Appends a Markdown line. Useful for "intro text" before a component. |
-| `ui` | Mounts a registered component. `component` is the name in `GenUIRegistry`. `id` becomes the component's identity within this stream. |
+| `ui` | Mounts a registered component. `component` is the name in `GenUIRegistry`. `id` becomes the component's identity within this stream — re-send the same id to [update it in place](#updating-a-component-in-place). |
 | `event` | Sent by the bot to update an already-mounted component. If `for` is set, only the component with that `id` receives it. Otherwise it's broadcast to all listeners in the message bubble. |
+
+## Updating a component in place
+
+`id` is the component's identity within the stream, and re-sending a `ui` chunk
+under an id already on screen **replaces** it — same element, new props. That is
+how a progress bar advances, a form flips to its success state, or an order card
+moves from *Preparing* to *Delivered* without stacking three cards in the bubble.
+
+```ts
+// one element, three renders
+onChunk({ type: "ui", component: "order-card", id: "card-1", props: { status: "Preparing" } });
+onChunk({ type: "ui", component: "order-card", id: "card-1", props: { status: "In transit" } });
+onChunk({ type: "ui", component: "order-card", id: "card-1", props: { status: "Delivered" } });
+```
+
+What the client does with that:
+
+1. **ChatEngine** merges the chunk into the message's chunk list. A `ui` chunk
+   whose id is already there overwrites that entry *in position*; a new id is
+   appended. Event chunks always append — they are a log, not a thing on screen.
+2. **GenUIMessage** keeps one element instance per chunk id and assigns the
+   latest props to it, so the DOM node survives the update: focus, scroll
+   position and internal component state stay put. Only what changed re-renders.
+3. If an id is reused for a *different* `component`, the element is rebuilt at
+   the same position rather than having another component's props assigned onto
+   it.
+
+### Two elements, interleaved
+
+Ids are per stream, so distinct elements update independently and keep their
+order of first appearance:
+
+```
+ui card-1  { status: "Preparing" }        → card mounted
+ui card-1  { status: "In transit" }       → card updated
+ui strip-1 { step: "Picked up" }          → strip mounted below it
+ui strip-1 { step: "Out for delivery" }   → strip updated
+```
+
+Result: two elements, four renders. Not four elements.
+
+### Pace it, or you won't see it
+
+An update that arrives in the same millisecond as the mount is invisible — the
+element simply appears in its final state. If you are demoing or debugging an
+in-place update, put a real delay between the emissions on the server; the
+client has no animation of its own to slow it down.
+
+### Ids and pauses
+
+If your backend pauses mid-turn for a human (mekik's interrupts), keep two things
+in mind:
+
+- **Mounted components outlive the pause.** They stay on screen while the chips
+  render, and the answer can update them — an approval that edits a widget
+  already in the transcript.
+- **Use explicit, stable ids across the pause.** A resume replays the node, so an
+  id minted from a counter can drift; a literal like `"card-1"` cannot. In mekik,
+  wrap the pre-pause emissions in `ctx.step` so the replay doesn't re-send states
+  the user already watched.
 
 ## Emitting chunks from a connector
 

--- a/website/docs/genui/streaming.md
+++ b/website/docs/genui/streaming.md
@@ -1,4 +1,8 @@
 ---
+sidebar_position: 2
+title: Streaming protocol
+description: The GenUI chunk protocol — text, ui and event chunks, in-place updates by chunk id, and events back from a component.
+---
 # GenUI streaming protocol
 
 A connector advertises GenUI support by implementing `onGenUIChunk(callback)`. The engine then renders any chunks the connector emits as a single synthetic `genui` message.


### PR DESCRIPTION
The client half of mekik `PROTOCOL.md` §10. Backend counterpart: AimTune/mekik#10.

**Server-defined components.** The backend announces a catalog on connect and `@chativa/genui` turns each definition into a custom element, so a `{ type: "ui", component: "order-card" }` chunk mounts a widget nobody compiled into the page. Cached in `localStorage` under the server URL and validated by a hash riding along on the `hello` frame the connector already sends — so a returning user's widgets render before the server answers, at no extra round trip.

**What its buttons do.** `<chativa-html>` bound exactly one attribute, `data-event`, and the backend had to guess who the click was for. Now the attribute *is* the answer:

| attribute | `scope` sent | meaning |
|---|---|---|
| `component-event="rate_delivery"` | `"component"` | the widget's own conversation with the graph node that mounted it |
| `mekik-event="track_order"` | `"graph"` | the application, which may start a new turn |
| `data-event="…"` | none | let the backend decide (the original form) |

Most specific wins, an empty value is not a trigger, and forms carry the scope too.

## Threading it through

`scope` and the originating `component` reach the backend as optional fields on the `genui_event` frame, carried as one optional `GenUIEventOptions` argument:

```
GenUIHtmlElement → sendEvent(type, payload, { scope })
GenUIMessage     → stamps `component` from the chunk
ChatWidget / AgentPanel → ChatEngine.receiveComponentEvent(…, opts)
IConnector       → receiveComponentEvent(streamId, eventType, payload, opts?)
createGenUIEventFrame → { type, streamId, eventType, payload, scope?, component? }
```

**Optional at every hop on purpose.** A `data-event` still makes the two-argument `sendEvent` call it always made, and a frame with no routing metadata is byte-for-byte the frame backends see today. All five connectors pass `opts` through; ones whose protocol doesn't model routing simply never receive it.

The component name is stamped by `GenUIMessage`, not by the component — only the chunk knows which widget an interaction came from, and asking components to report it themselves is asking for it to be wrong.

## MekikConnector

An `interrupt` frame carrying `data.event` now renders **nothing**. That pause is waiting for a widget already on screen, so default Approve/Cancel chips would be a dead end: tapping Approve sends a `resume` the node isn't waiting for.

## Verified against the real backend

Not by inspection — I fed chativa's `createGenUIEventFrame` output straight into a live mekik app:

```
interrupt data: {"payload":{},"event":"rate_delivery"}
chativa frame:  {"type":"genui_event","streamId":"…","eventType":"rate_delivery",
                 "payload":{"stars":5},"scope":"component","component":"delivery-card"}
  ✓ a component-event frame resolves the node parked on onEvent
  ✓ …and never reaches the graph handler
  ✓ a mekik-event frame reaches the graph handler, carrying the component name
  ✓ a plain data-event produces no scope key, and still reaches the handler
  ✓ an unknown scope is rejected as bad_request
```

Plus **570 tests** passing and **13 packages** typechecking.

## Reviewer notes

- `GenUIComponentAPI.sendEvent` gained an optional third parameter — source-compatible for every existing component.
- One existing `ChatEngine` test was updated: it asserted `receiveComponentEvent` arity, which changed by one optional argument. A new test covers the forwarding.
- The new attributes need the mekik side to interpret `scope`; that's AimTune/mekik#10.

🤖 Generated with [Claude Code](https://claude.com/claude-code)