### PR TITLE
feat(rn-webview): mekik connector + GenUI bridge, fix dead EventBus b…

### DIFF
--- a/examples/rn-webview-expo/App.tsx
+++ b/examples/rn-webview-expo/App.tsx
@@ -1,8 +1,28 @@
 import { useRef } from "react";
 import { Button, SafeAreaView, StyleSheet, Text, View } from "react-native";
 import { StatusBar } from "expo-status-bar";
-import { ChativaWebView, sendToChativaWebView } from "@chativa/rn-webview";
+import { ChativaWebView, sendToChativaWebView, type ChativaConnectorSpec } from "@chativa/rn-webview";
 import type WebView from "react-native-webview";
+
+// Flip to true to run against a mekik dev server instead of the zero-infra
+// dummy connector. A device or emulator can't reach your machine's
+// `localhost` — use your LAN IP (or `10.0.2.2` on the Android emulator).
+const USE_MEKIK = false;
+const MEKIK_URL = "ws://192.168.1.10:8790/chat";
+
+const connector: ChativaConnectorSpec = USE_MEKIK
+  ? {
+      type: "mekik",
+      options: {
+        url: MEKIK_URL,
+        resumeConversation: true,
+        // Auth is *described*, not passed: this plain object is rebuilt into a
+        // real TokenAuth instance inside the WebView (class instances can't
+        // cross the JSON bridge). Drop it for servers that don't authenticate.
+        auth: { kind: "token", token: "dev-token" },
+      },
+    }
+  : { type: "dummy", options: { replyDelay: 500, connectDelay: 0 } };
 
 export default function App() {
   const webViewRef = useRef<WebView>(null);
@@ -14,21 +34,39 @@ export default function App() {
         <Text style={styles.subtitle}>
           ChativaWebView embeds the same web widget used by @chativa/react —
           the connector runs entirely inside the WebView's own browser
-          engine, so DummyConnector (and any @chativa/connector-* package)
-          works completely unmodified.
+          engine, so DummyConnector (and any @chativa/connector-* package,
+          including mekik with its server-defined GenUI components) works
+          completely unmodified.
         </Text>
         <View style={styles.buttonRow}>
           <Button
-            title="Set dark accent theme"
+            title="Dark theme"
             onPress={() =>
-              // Live theme update after mount goes through the bridge, not a
-              // prop change — changing connector/theme props would fully
-              // reload the WebView and reconnect. See the package README.
+              // Live commands after mount go through the bridge, not a prop
+              // change — changing connector/theme props would fully reload
+              // the WebView and reconnect. See the package README.
               sendToChativaWebView(webViewRef, {
                 type: "set_theme",
                 payload: { colors: { primary: "#111827" } },
               })
             }
+          />
+          <Button
+            title="Say hi"
+            onPress={() =>
+              sendToChativaWebView(webViewRef, {
+                type: "send_message",
+                payload: { text: "Hello from native!" },
+              })
+            }
+          />
+          <Button
+            title="Open"
+            onPress={() => sendToChativaWebView(webViewRef, { type: "open_widget" })}
+          />
+          <Button
+            title="Close"
+            onPress={() => sendToChativaWebView(webViewRef, { type: "close_widget" })}
           />
         </View>
       </View>
@@ -36,12 +74,22 @@ export default function App() {
       <ChativaWebView
         ref={webViewRef}
         style={styles.webview}
-        connector={{ type: "dummy", options: { replyDelay: 500, connectDelay: 0 } }}
+        connector={connector}
         theme={{ colors: { primary: "#7c3aed", secondary: "#4f46e5" } }}
         onReady={() => console.log("[chativa] bridge ready")}
         onMessage={(message) => console.log("[chativa] message received:", message)}
         onMessageSent={(message) => console.log("[chativa] message sent:", message)}
         onConnect={() => console.log("[chativa] connector connected")}
+        // Server-defined GenUI components (mekik `genui_components` frames)
+        // render inside the WebView; these callbacks let native code observe
+        // the catalog registration and each stream's lifecycle.
+        onGenUIComponentsRegistered={({ components }) =>
+          console.log("[chativa] genui catalog registered:", components)
+        }
+        onGenUIStreamStarted={({ streamId }) => console.log("[chativa] genui stream started:", streamId)}
+        onGenUIStreamCompleted={({ streamId }) => console.log("[chativa] genui stream completed:", streamId)}
+        onToolCallUpdated={(toolCall) => console.log("[chativa] tool call:", toolCall)}
+        onAuthError={({ code, message }) => console.warn("[chativa] auth rejected:", code, message)}
         onError={(message) => console.warn("[chativa] bridge error:", message)}
       />
 
@@ -73,6 +121,9 @@ const styles = StyleSheet.create({
   },
   buttonRow: {
     marginTop: 12,
+    flexDirection: "row",
+    flexWrap: "wrap",
+    gap: 8,
     alignItems: "flex-start",
   },
   webview: {

--- a/examples/rn-webview-expo/README.md
+++ b/examples/rn-webview-expo/README.md
@@ -30,9 +30,33 @@ auto-detects the pnpm workspace root from `pnpm-workspace.yaml` — no manual
   for the web, completely unmodified.
 - `onMessage` / `onMessageSent` / `onConnect` / `onReady` / `onError` — the
   bridge surfaces the same event shape `@chativa/react`'s `<ChatIva>` does.
-- `sendToChativaWebView(ref, { type: "set_theme", payload })` — pushing a
-  live update into an already-mounted WebView, rather than relying on a prop
-  change (which would reload the page and reconnect).
+- `sendToChativaWebView(ref, ...)` — pushing live commands into an
+  already-mounted WebView (`set_theme`, `send_message`, `open_widget`,
+  `close_widget`), rather than relying on a prop change (which would reload
+  the page and reconnect).
+- GenUI observability callbacks (`onGenUIComponentsRegistered`,
+  `onGenUIStreamStarted/Completed`, `onToolCallUpdated`, `onAuthError`) —
+  logged to the console; they fire when a server streams GenUI.
+
+## Mekik smoke test (server-defined GenUI components)
+
+Set `USE_MEKIK = true` at the top of `App.tsx` and point `MEKIK_URL` at a
+running mekik dev server. A device/emulator can't reach your machine's
+`localhost` — use your LAN IP, or `10.0.2.2` from the Android emulator.
+
+Expected console sequence after connecting and sending a prompt that streams
+a server-defined component:
+
+1. `genui catalog registered: [{name, version, tag}, ...]` — the server's
+   `genui_components` frame was registered as custom elements.
+2. `genui stream started: <streamId>` → the component renders in the chat →
+   `genui stream completed: <streamId>`.
+3. Tapping a `component-event`/`mekik-event` button inside the rendered
+   component round-trips to the server entirely inside the WebView (watch
+   the server logs for the `genui_event` frame).
+4. On an app reload, the catalog comes from the WebView's localStorage cache
+   (the `hello` frame carries `componentsHash`; the server replies
+   `unchanged: true`).
 
 ## Not verified by an automated check
 

--- a/packages/rn-webview/README.md
+++ b/packages/rn-webview/README.md
@@ -27,12 +27,16 @@ out to be insufficient in a real app" — not committed work.
 `<ChativaWebView>` renders a `react-native-webview` pointed at a
 self-contained HTML document built by `buildBootstrapHtml()`. That document:
 
-1. Loads `@chativa/core`, `@chativa/ui` (which itself pulls in
-   `@chativa/genui`), and whichever connector script the `connector` prop
-   asks for — each from that package's own CDN/global (IIFE) build, via
-   jsdelivr by default (`https://cdn.jsdelivr.net/npm/<pkg>@latest/dist/...`).
+1. Loads `@chativa/ui` (which bundles `@chativa/core` + `@chativa/genui`)
+   and whichever connector script the `connector` prop asks for — each from
+   that package's own CDN/global (IIFE) build, via jsdelivr by default
+   (`https://cdn.jsdelivr.net/npm/<pkg>@latest/dist/...`).
    Override `cdnBaseUrl`/`versions` to pin exact versions or point at bundled
-   local assets for offline use.
+   local assets for offline use. **Requires `@chativa/ui` >= 0.10** — the
+   bridge binds to `window.Chativa.EventBus`/`window.Chativa.chatStore` (the
+   singletons *inside* the ui bundle, i.e. the exact instances `<chat-iva>`
+   uses); older ui builds don't expose them and the bridge reports a loud
+   `error` instead of silently observing a second, disconnected copy of core.
 2. Constructs the connector (`new window.<Global>.<ClassName>(options)`) and
    assigns `window.chativaSettings` — the *same* global-config convention
    `@chativa/core`'s `applyGlobalSettings()` already reads on the web, just
@@ -45,15 +49,16 @@ self-contained HTML document built by `buildBootstrapHtml()`. That document:
    `ReactNativeWebView.postMessage`, which `<ChativaWebView>` turns back into
    the same event props `@chativa/react`'s `<ChatIva>` exposes: `onMessage`,
    `onMessageSent`, `onConnect`, `onDisconnect`, `onSurveySubmit`,
-   `onWidgetOpen`, `onWidgetClose`.
+   `onWidgetOpen`, `onWidgetClose` — plus GenUI observability:
+   `onGenUIComponentsRegistered`, `onGenUIStreamStarted`,
+   `onGenUIStreamCompleted`, `onToolCallUpdated`, and `onAuthError`.
 
 Because the widget's JS (core + connector + UI) genuinely runs inside the
 WebView's browser engine, **every existing `@chativa/connector-*` package
 works completely unmodified** — `connector-websocket`, `-signalr`,
-`-directline`, `-sse`, `-http` all already have CDN builds (see each
-package's `jsdelivr` field / `vite.config.cdn.ts`). A connector without one
-(e.g. `@chativa/connector-mekik`, or a private connector) still works via
-`{ type: "custom", scriptUrl, globalName, className, options }`.
+`-directline`, `-sse`, `-http`, `-mekik` all already have CDN builds (see
+each package's `jsdelivr` field / `vite.config.cdn.ts`). A private connector
+still works via `{ type: "custom", scriptUrl, globalName, className, options }`.
 
 ```tsx
 import { ChativaWebView } from "@chativa/rn-webview";
@@ -65,15 +70,91 @@ import { ChativaWebView } from "@chativa/rn-webview";
 />;
 ```
 
-Live theme updates after mount go through the bridge rather than a prop
-change (changing `connector`/`theme` props doesn't re-render the HTML — that
-would fully reload the WebView and reconnect):
+Live commands after mount go through the bridge rather than a prop change
+(changing `connector`/`theme` props doesn't re-render the HTML — that would
+fully reload the WebView and reconnect):
 
 ```tsx
 import { sendToChativaWebView } from "@chativa/rn-webview";
 
 sendToChativaWebView(webViewRef, { type: "set_theme", payload: { colors: { primary: "#000" } } });
+sendToChativaWebView(webViewRef, { type: "send_message", payload: { text: "Hello" } });
+sendToChativaWebView(webViewRef, { type: "open_widget" });
+sendToChativaWebView(webViewRef, { type: "close_widget" });
 ```
+
+## Mekik connector + server-defined GenUI components
+
+`connector: { type: "mekik", options }` connects the WebView-hosted widget
+straight to a mekik server. Server-defined GenUI components — the
+`genui_components` catalog frames (`{name, template, css, props, version}`)
+— render inside the WebView exactly as on the web: the widget registers each
+definition as a custom element and streamed `genui` chunks instantiate them.
+RN observes the flow through the GenUI callbacks:
+
+```tsx
+<ChativaWebView
+  connector={{
+    type: "mekik",
+    options: {
+      url: "ws://192.168.1.10:8790/chat", // a device can't reach your machine's `localhost`
+      resumeConversation: true,
+      auth: { kind: "token", token: "my-api-key" },
+    },
+  }}
+  onGenUIComponentsRegistered={({ components }) => console.log("catalog:", components)}
+  onGenUIStreamStarted={({ streamId }) => console.log("stream started", streamId)}
+  onGenUIStreamCompleted={({ streamId }) => console.log("stream done", streamId)}
+  onAuthError={({ code, message }) => console.warn("auth rejected:", code, message)}
+  style={{ flex: 1 }}
+/>
+```
+
+`onGenUIComponentsRegistered` delivers **summaries only** (`name`/`version`/
+`tag`) — the full template stays inside the WebView where it renders.
+Component events (`component-event`/`mekik-event`/`data-event` buttons in a
+rendered widget) round-trip to the server entirely inside the WebView; RN
+doesn't need to participate.
+
+**Auth is described, not passed.** `MekikConnectorOptions.auth` normally takes
+a live `TokenAuth`/`CookieAuth` instance, but a class instance can't cross the
+JSON bridge. The spec's `auth` field is a plain object rebuilt into the real
+adapter inside the WebView:
+
+- `auth: { kind: "token", token, transport?, queryParam?, maxRetries? }` →
+  `new TokenAuth({...})`. Only a *string* token — a token-minting function
+  can't be serialized (use `@chativa/react` or a `custom` connector script if
+  you need one).
+- `auth: { kind: "cookie" }` → `new CookieAuth()`. The `refresh` callback is
+  likewise unsupported over the bridge.
+- `onAuthError` can't be passed either; the bootstrap wires it and surfaces
+  rejections as the `onAuthError` prop.
+
+## Bridge message reference
+
+Outbound (WebView → RN), delivered as the matching callback prop:
+
+| message | payload | prop |
+|---|---|---|
+| `ready` | — | `onReady` |
+| `message_received` | `IncomingMessage` | `onMessage` |
+| `message_sent` | `OutgoingMessage` | `onMessageSent` |
+| `connector_status_changed` | `{status}` | `onConnect` / `onDisconnect` |
+| `survey_submitted` | `SurveyPayload` | `onSurveySubmit` |
+| `widget_opened` / `widget_closed` | — | `onWidgetOpen` / `onWidgetClose` |
+| `genui_components_registered` | `{components: [{name, version?, tag?}]}` | `onGenUIComponentsRegistered` |
+| `genui_stream_started` / `genui_stream_completed` | `{streamId}` | `onGenUIStreamStarted` / `onGenUIStreamCompleted` |
+| `tool_call_updated` | `ToolCall` | `onToolCallUpdated` |
+| `auth_error` | `{code, message}` | `onAuthError` |
+| `error` | `{message}` | `onError` |
+
+Inbound (RN → WebView), via `sendToChativaWebView(ref, msg)`:
+
+| message | payload | effect |
+|---|---|---|
+| `set_theme` | `DeepPartial<ThemeConfig>` | live theme update |
+| `send_message` | `{text, markdown?}` | sends a user message (same path as typing it) |
+| `open_widget` / `close_widget` | — | `chatStore.open()` / `.close()` |
 
 ## Building
 
@@ -107,7 +188,11 @@ builds packages in dependency order.
   `file://` base in principle, but nothing here packages `dist/*.global.js`
   files as RN assets; today this requires the device to have network access
   to jsdelivr (or an override URL).
-- No tests yet.
+- **No RN-originated GenUI component events** — a rendered widget's buttons
+  round-trip inside the WebView, but native code can't synthesize a
+  component event (there's no `msgId` on the RN side to target). Part of the
+  native-renderer follow-up (#29/#30) along with bridging full
+  `GenUIComponentDefinition` payloads for true native rendering.
 
 ## `DOM` leaks in `@chativa/core`
 

--- a/packages/rn-webview/package.json
+++ b/packages/rn-webview/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chativa/rn-webview",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "description": "Chativa RN WebView — embeds the Chativa web chat widget in a react-native-webview, bridged to native props/callbacks, so any existing @chativa/connector-* works unmodified. See README.md for architecture and the native-fallback tracking issues.",
   "author": "Hamza Agar",
   "license": "MIT",
@@ -46,8 +46,8 @@
   },
   "scripts": {
     "build": "bob build",
-    "test": "echo \"@chativa/rn-webview: no tests yet\"",
-    "typecheck": "tsc --noEmit"
+    "test": "vitest run --passWithNoTests",
+    "typecheck": "tsc --noEmit && tsc -p tsconfig.compat.json --noEmit"
   },
   "dependencies": {
     "@chativa/core": "workspace:*"
@@ -59,13 +59,15 @@
     "react-native-webview": ">=13.0.0"
   },
   "devDependencies": {
+    "@chativa/connector-mekik": "workspace:*",
     "@react-native/babel-preset": "^0.86.1",
     "@types/react": "^19.2.17",
     "react": "^19.2.8",
     "react-native": "^0.86.0",
     "react-native-builder-bob": "^0.43.0",
     "react-native-webview": "^14.0.1",
-    "typescript": "~5.8.3"
+    "typescript": "~5.8.3",
+    "vitest": "^4.0.18"
   },
   "react-native-builder-bob": {
     "source": "src",

--- a/packages/rn-webview/src/ChativaWebView.tsx
+++ b/packages/rn-webview/src/ChativaWebView.tsx
@@ -8,9 +8,10 @@ import type {
   OutgoingMessage,
   SurveyPayload,
   ThemeConfig,
+  ToolCall,
 } from "@chativa/core";
 import { buildBootstrapHtml, type BuildBootstrapHtmlOptions } from "./bridge/bootstrapHtml";
-import type { BridgeOutMessage, ChativaConnectorSpec } from "./bridge/types";
+import type { BridgeOutMessage, ChativaConnectorSpec, GenUIComponentSummary } from "./bridge/types";
 
 // `react-native-webview`'s default export is `class WebView<P = undefined>
 // extends Component<WebViewProps & P>` — used bare (no type argument),
@@ -46,6 +47,20 @@ export interface ChativaWebViewProps {
   /** The chat panel opened. Fires once immediately — the embedded widget has no launcher and opens on load. */
   onWidgetOpen?: () => void;
   onWidgetClose?: () => void;
+  /**
+   * The server announced GenUI component definitions and the widget registered
+   * them as custom elements. Summaries only (name/version/tag) — the full
+   * template renders inside the WebView.
+   */
+  onGenUIComponentsRegistered?: (payload: { components: GenUIComponentSummary[] }) => void;
+  /** A GenUI stream started (first chunk received). */
+  onGenUIStreamStarted?: (payload: { streamId: string }) => void;
+  /** A GenUI stream completed. */
+  onGenUIStreamCompleted?: (payload: { streamId: string }) => void;
+  /** A connector tool call started or changed state (upsert by `id`). */
+  onToolCallUpdated?: (toolCall: ToolCall) => void;
+  /** The server rejected the connection (mekik connector's `onAuthError`). */
+  onAuthError?: (payload: { code: string; message: string }) => void;
   /** An error was thrown while wiring up the bridge inside the WebView. */
   onError?: (message: string) => void;
 }
@@ -82,6 +97,11 @@ export const ChativaWebView = React.forwardRef<RNWebView, ChativaWebViewProps>(f
     onSurveySubmit,
     onWidgetOpen,
     onWidgetClose,
+    onGenUIComponentsRegistered,
+    onGenUIStreamStarted,
+    onGenUIStreamCompleted,
+    onToolCallUpdated,
+    onAuthError,
     onError,
   },
   ref,
@@ -127,12 +147,42 @@ export const ChativaWebView = React.forwardRef<RNWebView, ChativaWebViewProps>(f
         case "widget_closed":
           onWidgetClose?.();
           break;
+        case "genui_components_registered":
+          onGenUIComponentsRegistered?.(data.payload);
+          break;
+        case "genui_stream_started":
+          onGenUIStreamStarted?.(data.payload);
+          break;
+        case "genui_stream_completed":
+          onGenUIStreamCompleted?.(data.payload);
+          break;
+        case "tool_call_updated":
+          onToolCallUpdated?.(data.payload);
+          break;
+        case "auth_error":
+          onAuthError?.(data.payload);
+          break;
         case "error":
           onError?.(data.payload.message);
           break;
       }
     },
-    [onReady, onMessage, onMessageSent, onConnect, onDisconnect, onSurveySubmit, onWidgetOpen, onWidgetClose, onError],
+    [
+      onReady,
+      onMessage,
+      onMessageSent,
+      onConnect,
+      onDisconnect,
+      onSurveySubmit,
+      onWidgetOpen,
+      onWidgetClose,
+      onGenUIComponentsRegistered,
+      onGenUIStreamStarted,
+      onGenUIStreamCompleted,
+      onToolCallUpdated,
+      onAuthError,
+      onError,
+    ],
   );
 
   return (

--- a/packages/rn-webview/src/bridge/__tests__/bootstrapHtml.test.ts
+++ b/packages/rn-webview/src/bridge/__tests__/bootstrapHtml.test.ts
@@ -1,0 +1,107 @@
+import { describe, it, expect } from "vitest";
+import { buildBootstrapHtml } from "../bootstrapHtml";
+import type { ChativaConnectorSpec } from "../types";
+
+const dummySpec: ChativaConnectorSpec = { type: "dummy" };
+
+function html(connector: ChativaConnectorSpec, extra?: { versions?: Record<string, string> }) {
+  return buildBootstrapHtml({ settings: { connector }, versions: extra?.versions });
+}
+
+describe("buildBootstrapHtml — script loading", () => {
+  it("loads the connector script and the ui bundle, but no separate core script", () => {
+    const out = html(dummySpec);
+    expect(out).toContain("@chativa/connector-dummy@latest/dist/chativa-dummy.global.js");
+    expect(out).toContain("@chativa/ui@latest/dist/chativa.global.js");
+    // The ui bundle carries its own copy of core; loading chativa-core.global.js
+    // separately would create a second, disconnected EventBus/chatStore.
+    expect(out).not.toContain("chativa-core.global.js");
+  });
+
+  it("pins versions per package", () => {
+    const out = buildBootstrapHtml({
+      settings: { connector: { type: "mekik", options: { url: "ws://h/chat" } } },
+      versions: { ui: "0.10.0", mekik: "0.0.1" },
+    });
+    expect(out).toContain("@chativa/ui@0.10.0/dist/chativa.global.js");
+    expect(out).toContain("@chativa/connector-mekik@0.0.1/dist/chativa-mekik.global.js");
+  });
+});
+
+describe("buildBootstrapHtml — singleton bridge binding", () => {
+  it("binds EventBus/chatStore from window.Chativa (the widget's own instances)", () => {
+    const out = html(dummySpec);
+    expect(out).toContain("var C = window.Chativa;");
+    expect(out).not.toContain("window.ChativaCore");
+  });
+
+  it("fails loudly when the ui bundle is too old to expose the singletons", () => {
+    const out = html(dummySpec);
+    expect(out).toContain("@chativa/ui >= 0.10 required");
+  });
+});
+
+describe("buildBootstrapHtml — mekik connector", () => {
+  it("constructs MekikConnector from the ChativaMekik global", () => {
+    const out = html({ type: "mekik", options: { url: "ws://h/chat", resumeConversation: true } });
+    expect(out).toContain('window["ChativaMekik"]');
+    expect(out).toContain("new g.MekikConnector(o)");
+    expect(out).toContain('"resumeConversation":true');
+  });
+
+  it("rebuilds token auth as a real TokenAuth instance (kind stripped)", () => {
+    const out = html({
+      type: "mekik",
+      options: { url: "ws://h/chat", auth: { kind: "token", token: "t-1", transport: "query" } },
+    });
+    expect(out).toContain('o.auth = new g.TokenAuth({"token":"t-1","transport":"query"});');
+    expect(out).not.toContain('"kind"');
+  });
+
+  it("rebuilds cookie auth as CookieAuth", () => {
+    const out = html({ type: "mekik", options: { url: "ws://h/chat", auth: { kind: "cookie" } } });
+    expect(out).toContain("o.auth = new g.CookieAuth();");
+  });
+
+  it("sets no auth when the spec has none, and always bridges onAuthError", () => {
+    const out = html({ type: "mekik", options: { url: "ws://h/chat" } });
+    expect(out).not.toContain("o.auth =");
+    expect(out).toContain('o.onAuthError = function (e) { post({ type: "auth_error"');
+  });
+
+  it("passes the plain-string token shorthand through untouched", () => {
+    const out = html({ type: "mekik", options: { url: "ws://h/chat", token: "legacy" } });
+    expect(out).toContain('"token":"legacy"');
+  });
+});
+
+describe("buildBootstrapHtml — GenUI bridging", () => {
+  it("forwards GenUI and tool-call EventBus events to React Native", () => {
+    const out = html(dummySpec);
+    expect(out).toContain('EventBus.on("genui_components_registered"');
+    expect(out).toContain('EventBus.on("genui_stream_started"');
+    expect(out).toContain('EventBus.on("genui_stream_completed"');
+    expect(out).toContain('EventBus.on("tool_call_updated"');
+    // Summaries only — the full template/css stays inside the WebView.
+    expect(out).toContain("{ name: d.name, version: d.version, tag: d.tag }");
+  });
+});
+
+describe("buildBootstrapHtml — inbound commands", () => {
+  it("handles set_theme, send_message, open_widget and close_widget", () => {
+    const out = html(dummySpec);
+    expect(out).toContain('case "set_theme":');
+    expect(out).toContain('case "send_message":');
+    expect(out).toContain('case "open_widget":');
+    expect(out).toContain('case "close_widget":');
+    expect(out).toContain('new CustomEvent("chat-action"');
+  });
+});
+
+describe("buildBootstrapHtml — inline JSON safety", () => {
+  it("escapes </script> inside option values so it can't break out of the block", () => {
+    const out = html({ type: "dummy", options: { greeting: "</script><script>alert(1)</script>" } });
+    expect(out).not.toContain("</script><script>alert(1)");
+    expect(out).toContain("\\u003c/script>");
+  });
+});

--- a/packages/rn-webview/src/bridge/__tests__/mekikSpecCompat.test.ts
+++ b/packages/rn-webview/src/bridge/__tests__/mekikSpecCompat.test.ts
@@ -1,0 +1,27 @@
+/**
+ * Drift guard: `MekikConnectorSpecOptions` / `MekikAuthSpec` are defined
+ * locally (so the published .d.ts gains no dependency) as JSON-safe mirrors of
+ * `@chativa/connector-mekik`'s real option types. These assignability checks
+ * fail `tsc --noEmit` if the connector's options ever change shape underneath
+ * the mirror — e.g. a renamed field or a narrowed union.
+ */
+import { describe, it, expect } from "vitest";
+import type { MekikConnectorOptions, TokenAuthOptions } from "@chativa/connector-mekik";
+import type { MekikAuthSpec, MekikConnectorSpecOptions } from "../types";
+
+// Everything except `auth` must be directly assignable to the real options —
+// the bootstrap spreads it into the constructor argument untouched.
+type SpecRest = Omit<MekikConnectorSpecOptions, "auth">;
+const _restAssignable = (o: SpecRest): MekikConnectorOptions => o;
+
+// The token spec (minus the `kind` discriminant) must be a valid TokenAuth
+// constructor argument — the bootstrap does `new g.TokenAuth({...rest})`.
+type TokenSpec = Extract<MekikAuthSpec, { kind: "token" }>;
+const _tokenAssignable = (o: Omit<TokenSpec, "kind">): TokenAuthOptions => o;
+
+describe("mekik spec type compatibility", () => {
+  it("compiles — assignability is enforced by tsc, not at runtime", () => {
+    expect(typeof _restAssignable).toBe("function");
+    expect(typeof _tokenAssignable).toBe("function");
+  });
+});

--- a/packages/rn-webview/src/bridge/__tests__/postMessage.test.ts
+++ b/packages/rn-webview/src/bridge/__tests__/postMessage.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect, vi } from "vitest";
+import type WebView from "react-native-webview";
+import { sendToChativaWebView } from "../postMessage";
+import type { BridgeInMessage } from "../types";
+
+function fakeRef() {
+  const injectJavaScript = vi.fn();
+  return {
+    ref: { current: { injectJavaScript } as unknown as WebView },
+    injectJavaScript,
+  };
+}
+
+describe("sendToChativaWebView", () => {
+  it("injects a MessageEvent carrying the JSON-encoded message", () => {
+    const { ref, injectJavaScript } = fakeRef();
+    const msg: BridgeInMessage = { type: "send_message", payload: { text: "hi", markdown: true } };
+    sendToChativaWebView(ref, msg);
+
+    expect(injectJavaScript).toHaveBeenCalledTimes(1);
+    const injected = injectJavaScript.mock.calls[0][0] as string;
+    expect(injected).toContain('new MessageEvent("message"');
+    expect(injected).toContain(JSON.stringify(JSON.stringify(msg)));
+  });
+
+  it("is a no-op on an empty ref", () => {
+    expect(() => sendToChativaWebView({ current: null }, { type: "open_widget" })).not.toThrow();
+  });
+});

--- a/packages/rn-webview/src/bridge/bootstrapHtml.ts
+++ b/packages/rn-webview/src/bridge/bootstrapHtml.ts
@@ -1,4 +1,8 @@
-import type { BuiltinConnectorType, ChativaWebViewSettings } from "./types";
+import type {
+  BuiltinConnectorType,
+  ChativaWebViewSettings,
+  MekikConnectorSpecOptions,
+} from "./types";
 
 /**
  * Maps a built-in connector type to its CDN/global (IIFE) build — same
@@ -45,31 +49,72 @@ const BUILTIN_CONNECTORS: Record<
     globalName: "ChativaSse",
     className: "SseConnector",
   },
+  mekik: {
+    pkg: "@chativa/connector-mekik",
+    file: "chativa-mekik.global.js",
+    globalName: "ChativaMekik",
+    className: "MekikConnector",
+  },
 };
 
 const DEFAULT_CDN_BASE_URL = "https://cdn.jsdelivr.net/npm";
 
 /** JSON-encode a value for inlining into a `<script>` block, without letting `</script>` break out early. */
 function inlineJson(value: unknown): string {
-  return JSON.stringify(value).replace(/</g, "\\u003c");
+  const json = JSON.stringify(value);
+  // JSON.stringify(undefined) is undefined (not a string) — inline the literal
+  // so an omitted setting stays absent instead of throwing here.
+  return json === undefined ? "undefined" : json.replace(/</g, "\\u003c");
+}
+
+/**
+ * The mekik connector can't go through the generic `new g.MekikConnector(json)`
+ * path: its `auth` option is a class instance (`TokenAuth` / `CookieAuth`), and
+ * serializing one would produce a methodless plain object the connector can't
+ * call. Instead the JSON-safe `MekikAuthSpec` is rebuilt into a real adapter
+ * inside the WebView, and `onAuthError` (a callback, also unbridgeable) is
+ * wired here to surface rejections as `auth_error` bridge messages.
+ */
+function mekikConnectorExpr(options: MekikConnectorSpecOptions): string {
+  const { auth, ...rest } = options;
+  let authStmt = "";
+  if (auth?.kind === "token") {
+    const { kind: _kind, ...tokenOpts } = auth;
+    authStmt = `o.auth = new g.TokenAuth(${inlineJson(tokenOpts)});`;
+  } else if (auth?.kind === "cookie") {
+    authStmt = `o.auth = new g.CookieAuth();`;
+  }
+  return `(function () {
+          var g = window["ChativaMekik"];
+          var o = ${inlineJson(rest)};
+          ${authStmt}
+          o.onAuthError = function (e) { post({ type: "auth_error", payload: { code: e.code, message: e.message } }); };
+          return new g.MekikConnector(o);
+        })()`;
 }
 
 export interface BuildBootstrapHtmlOptions {
   settings: ChativaWebViewSettings;
   /** Base URL scripts are resolved against. Default: jsdelivr's `@latest` tag for each package. */
   cdnBaseUrl?: string;
-  /** Pin an exact version for a package instead of `@latest` (e.g. `{ core: "0.4.0" }`). */
-  versions?: Partial<Record<"core" | "ui" | BuiltinConnectorType, string>>;
+  /** Pin an exact version for a package instead of `@latest` (e.g. `{ ui: "0.10.0" }`). */
+  versions?: Partial<Record<"ui" | BuiltinConnectorType, string>>;
 }
 
 /**
  * Builds the self-contained HTML document loaded into the WebView: pulls in
- * the already-published `@chativa/core` + `@chativa/ui` (which itself pulls
- * in `@chativa/genui`) CDN builds plus whichever connector script the given
- * spec needs, constructs the connector, applies it via the same
+ * the already-published `@chativa/ui` CDN build (which bundles
+ * `@chativa/core` + `@chativa/genui`) plus whichever connector script the
+ * given spec needs, constructs the connector, applies it via the same
  * `window.chativaSettings` convention `@chativa/core` already reads on the
  * web, mounts `<chat-iva>`, and bridges `EventBus` to
  * `ReactNativeWebView.postMessage`.
+ *
+ * The bridge binds to `window.Chativa.EventBus` / `window.Chativa.chatStore`
+ * — the singletons *inside* the ui bundle, i.e. the exact instances
+ * `<chat-iva>` uses. (Binding to a separately loaded `chativa-core.global.js`
+ * would observe a second, disconnected copy of core: every callback would
+ * silently never fire.) Requires `@chativa/ui` >= 0.10.
  */
 export function buildBootstrapHtml({
   settings,
@@ -89,13 +134,15 @@ export function buildBootstrapHtml({
   } else {
     const entry = BUILTIN_CONNECTORS[settings.connector.type];
     connectorScripts.push(scriptUrl(entry.pkg, entry.file, versions[settings.connector.type]));
-    constructConnectorExpr = `new window[${inlineJson(entry.globalName)}][${inlineJson(entry.className)}](${inlineJson(settings.connector.options ?? {})})`;
+    constructConnectorExpr =
+      settings.connector.type === "mekik"
+        ? mekikConnectorExpr(settings.connector.options)
+        : `new window[${inlineJson(entry.globalName)}][${inlineJson(entry.className)}](${inlineJson(settings.connector.options ?? {})})`;
   }
 
-  const coreScript = scriptUrl("@chativa/core", "chativa-core.global.js", versions.core);
   const uiScript = scriptUrl("@chativa/ui", "chativa.global.js", versions.ui);
 
-  const scriptTags = [coreScript, ...connectorScripts, uiScript]
+  const scriptTags = [...connectorScripts, uiScript]
     .map((src) => `<script src="${src}"></script>`)
     .join("\n    ");
 
@@ -113,6 +160,12 @@ export function buildBootstrapHtml({
     ${scriptTags}
     <script>
       (function () {
+        function post(message) {
+          if (window.ReactNativeWebView) {
+            window.ReactNativeWebView.postMessage(JSON.stringify(message));
+          }
+        }
+
         window.chativaSettings = {
           connector: ${constructConnectorExpr},
           theme: ${inlineJson({ ...(settings.theme ?? {}), windowMode: "inline", allowFullscreen: false })},
@@ -120,15 +173,14 @@ export function buildBootstrapHtml({
           i18n: ${inlineJson(settings.i18n)}
         };
 
-        function post(message) {
-          if (window.ReactNativeWebView) {
-            window.ReactNativeWebView.postMessage(JSON.stringify(message));
-          }
-        }
-
         function bridgeEvents() {
-          var EventBus = window.ChativaCore.EventBus;
-          var chatStore = window.ChativaCore.chatStore;
+          var C = window.Chativa;
+          if (!C || !C.EventBus || !C.chatStore) {
+            post({ type: "error", payload: { message: "@chativa/ui >= 0.10 required: EventBus/chatStore missing from window.Chativa" } });
+            return;
+          }
+          var EventBus = C.EventBus;
+          var chatStore = C.chatStore;
 
           EventBus.on("message_received", function (payload) { post({ type: "message_received", payload: payload }); });
           EventBus.on("message_sent", function (payload) { post({ type: "message_sent", payload: payload }); });
@@ -136,6 +188,15 @@ export function buildBootstrapHtml({
           EventBus.on("survey_submitted", function (payload) { post({ type: "survey_submitted", payload: payload }); });
           EventBus.on("widget_opened", function () { post({ type: "widget_opened" }); });
           EventBus.on("widget_closed", function () { post({ type: "widget_closed" }); });
+          EventBus.on("genui_components_registered", function (payload) {
+            var defs = (payload && payload.definitions) || [];
+            post({ type: "genui_components_registered", payload: { components: defs.map(function (d) {
+              return { name: d.name, version: d.version, tag: d.tag };
+            }) } });
+          });
+          EventBus.on("genui_stream_started", function (payload) { post({ type: "genui_stream_started", payload: payload }); });
+          EventBus.on("genui_stream_completed", function (payload) { post({ type: "genui_stream_completed", payload: payload }); });
+          EventBus.on("tool_call_updated", function (payload) { post({ type: "tool_call_updated", payload: payload }); });
 
           // Inline mode + no launcher button: the widget is the whole screen,
           // so it should already be "open" rather than waiting for a tap.
@@ -144,8 +205,26 @@ export function buildBootstrapHtml({
           function handleInbound(event) {
             var data;
             try { data = JSON.parse(event.data); } catch (e) { return; }
-            if (data && data.type === "set_theme") {
-              chatStore.getState().setTheme(data.payload || {});
+            if (!data || !data.type) return;
+            switch (data.type) {
+              case "set_theme":
+                chatStore.getState().setTheme(data.payload || {});
+                break;
+              case "send_message": {
+                var widget = document.querySelector("chat-iva");
+                if (widget && data.payload && data.payload.text) {
+                  widget.dispatchEvent(new CustomEvent("chat-action", {
+                    detail: { text: data.payload.text, markdown: !!data.payload.markdown }
+                  }));
+                }
+                break;
+              }
+              case "open_widget":
+                chatStore.getState().open();
+                break;
+              case "close_widget":
+                chatStore.getState().close();
+                break;
             }
           }
           document.addEventListener("message", handleInbound);

--- a/packages/rn-webview/src/bridge/types.ts
+++ b/packages/rn-webview/src/bridge/types.ts
@@ -5,12 +5,13 @@ import type {
   OutgoingMessage,
   SurveyPayload,
   ThemeConfig,
+  ToolCall,
 } from "@chativa/core";
 
 /**
  * Built-in connector types the bootstrap page knows how to load from a CDN
- * script by name. Anything else (e.g. `@chativa/connector-mekik`, or a
- * private connector) goes through `type: "custom"`.
+ * script by name. Anything else (e.g. a private connector) goes through
+ * `type: "custom"`.
  */
 export type BuiltinConnectorType =
   | "dummy"
@@ -18,7 +19,53 @@ export type BuiltinConnectorType =
   | "signalr"
   | "directline"
   | "http"
-  | "sse";
+  | "sse"
+  | "mekik";
+
+/**
+ * JSON-safe mirror of `@chativa/connector-mekik`'s auth adapters, reconstructed
+ * as a real `TokenAuth` / `CookieAuth` instance inside the WebView. Function
+ * credentials (a token-minting callback, `CookieAuth`'s `refresh`) can't cross
+ * the native/web bridge and are deliberately unsupported here — apps needing
+ * them should host the widget with `@chativa/react` or supply a `custom`
+ * connector script that builds its own provider.
+ */
+export type MekikAuthSpec =
+  | {
+      kind: "token";
+      token: string;
+      transport?: "hello" | "query";
+      queryParam?: string;
+      maxRetries?: number;
+    }
+  | { kind: "cookie" };
+
+/**
+ * JSON-safe subset of `MekikConnectorOptions` from `@chativa/connector-mekik`.
+ * Defined locally (not type-imported) so the published `.d.ts` gains no new
+ * dependency; a type-compatibility test guards against drift.
+ */
+export interface MekikConnectorSpecOptions {
+  /** mekik WebSocket endpoint, e.g. "ws://192.168.1.10:8790/chat". */
+  url: string;
+  protocols?: string | string[];
+  reconnect?: boolean;
+  reconnectDelay?: number;
+  maxReconnectAttempts?: number;
+  reconnectBackoff?: "fixed" | "exponential";
+  reconnectMaxDelay?: number;
+  routeInUrl?: boolean;
+  queueOfflineMessages?: boolean;
+  userId?: string;
+  conversationId?: string;
+  resumeConversation?: boolean;
+  auth?: MekikAuthSpec;
+  /**
+   * Plain-string shorthand only — the connector's function form can't cross
+   * the bridge; prefer `auth: { kind: "token", ... }`.
+   */
+  token?: string;
+}
 
 /**
  * Describes which connector to construct *inside the WebView*. A live
@@ -33,8 +80,12 @@ export type BuiltinConnectorType =
  */
 export type ChativaConnectorSpec =
   | {
-      type: BuiltinConnectorType;
+      type: Exclude<BuiltinConnectorType, "mekik">;
       options?: Record<string, unknown>;
+    }
+  | {
+      type: "mekik";
+      options: MekikConnectorSpecOptions;
     }
   | {
       type: "custom";
@@ -55,6 +106,18 @@ export interface ChativaWebViewSettings {
   i18n?: Record<string, unknown>;
 }
 
+/**
+ * Summary of a server-defined GenUI component the widget registered — name and
+ * version only. The full definition (template/css/props) stays inside the
+ * WebView where it's rendered; bridging it out is the native-renderer
+ * (Phase 2) concern.
+ */
+export interface GenUIComponentSummary {
+  name: string;
+  version?: string;
+  tag?: string;
+}
+
 // ── Outbound: WebView (web widget) -> React Native ────────────────────────
 
 export type BridgeOutMessage =
@@ -65,8 +128,17 @@ export type BridgeOutMessage =
   | { type: "survey_submitted"; payload: SurveyPayload }
   | { type: "widget_opened" }
   | { type: "widget_closed" }
+  | { type: "genui_components_registered"; payload: { components: GenUIComponentSummary[] } }
+  | { type: "genui_stream_started"; payload: { streamId: string } }
+  | { type: "genui_stream_completed"; payload: { streamId: string } }
+  | { type: "tool_call_updated"; payload: ToolCall }
+  | { type: "auth_error"; payload: { code: string; message: string } }
   | { type: "error"; payload: { message: string } };
 
 // ── Inbound: React Native -> WebView ───────────────────────────────────────
 
-export type BridgeInMessage = { type: "set_theme"; payload: DeepPartial<ThemeConfig> };
+export type BridgeInMessage =
+  | { type: "set_theme"; payload: DeepPartial<ThemeConfig> }
+  | { type: "send_message"; payload: { text: string; markdown?: boolean } }
+  | { type: "open_widget" }
+  | { type: "close_widget" };

--- a/packages/rn-webview/src/index.ts
+++ b/packages/rn-webview/src/index.ts
@@ -15,6 +15,9 @@ export type {
   BuiltinConnectorType,
   ChativaConnectorSpec,
   ChativaWebViewSettings,
+  GenUIComponentSummary,
+  MekikAuthSpec,
+  MekikConnectorSpecOptions,
 } from "./bridge/types";
 
 // Re-export core types so consumers don't need a separate `@chativa/core`

--- a/packages/rn-webview/tsconfig.compat.json
+++ b/packages/rn-webview/tsconfig.compat.json
@@ -1,0 +1,17 @@
+{
+  // Second typecheck pass for the mekik spec drift guard only. The main
+  // tsconfig can't host it: importing @chativa/connector-mekik's built
+  // dist/index.d.ts drags @chativa/core's *source* into the program (the
+  // rolled-up d.ts references ../../core/src/index.ts), and core's UI code
+  // needs the DOM lib this RN package deliberately drops. This pass keeps the
+  // base config's browser lib list and resolves both packages from source.
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "paths": {
+      "@chativa/core/frames": ["../core/src/frames.ts"],
+      "@chativa/core": ["../core/src/index.ts"],
+      "@chativa/connector-mekik": ["../connector-mekik/src/index.ts"]
+    }
+  },
+  "include": ["src/bridge/__tests__/mekikSpecCompat.test.ts", "src/bridge/types.ts"]
+}

--- a/packages/rn-webview/tsconfig.json
+++ b/packages/rn-webview/tsconfig.json
@@ -21,5 +21,10 @@
   },
   "include": [
     "src"
+  ],
+  // The mekik drift guard needs the DOM lib and source-resolved workspace
+  // packages — it runs in its own pass, see tsconfig.compat.json.
+  "exclude": [
+    "src/bridge/__tests__/mekikSpecCompat.test.ts"
   ]
 }

--- a/packages/rn-webview/vitest.config.ts
+++ b/packages/rn-webview/vitest.config.ts
@@ -1,0 +1,20 @@
+import { defineConfig } from "vitest/config";
+import path from "path";
+
+export default defineConfig({
+  resolve: {
+    // Resolve workspace packages from source so tests don't need pre-built
+    // dists. (The bridge sources only *type*-import from them, but a future
+    // value import shouldn't silently exercise a stale dist copy.)
+    alias: [
+      { find: "@chativa/core", replacement: path.resolve(__dirname, "../core/src/index.ts") },
+      {
+        find: "@chativa/connector-mekik",
+        replacement: path.resolve(__dirname, "../connector-mekik/src/index.ts"),
+      },
+    ],
+  },
+  test: {
+    include: ["src/**/__tests__/**/*.test.ts"],
+  },
+});

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,7 +1,7 @@
-{
+﻿{
   "name": "@chativa/ui",
-  "version": "0.9.0",
-  "description": "Chativa UI — LitElement web components for the chat widget (chat-iva, chat-bot-button).",
+  "version": "0.10.0",
+  "description": "Chativa UI â€” LitElement web components for the chat widget (chat-iva, chat-bot-button).",
   "author": "Hamza Agar",
   "license": "MIT",
   "type": "module",

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -11,6 +11,9 @@ export type { LocalizedCommandConfig, CommandTranslations } from "./commands/ind
 export { render } from "./render";
 export type { RenderOptions } from "./render";
 export { GenUIRegistry } from "@chativa/genui";
+// Singletons the rn-webview bootstrap bridges against — the CDN (IIFE) build
+// bundles core, so these are the same instances <chat-iva> itself uses.
+export { EventBus, chatStore } from "@chativa/core";
 
 // Side-effect registrations (registers custom elements)
 // @chativa/genui: registers genui-message custom element + MessageTypeRegistry.register("genui", ...)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -420,6 +420,9 @@ importers:
         specifier: workspace:*
         version: link:../core
     devDependencies:
+      '@chativa/connector-mekik':
+        specifier: workspace:*
+        version: link:../connector-mekik
       '@react-native/babel-preset':
         specifier: ^0.86.1
         version: 0.86.1(@babel/core@7.29.0)
@@ -441,6 +444,9 @@ importers:
       typescript:
         specifier: ~5.8.3
         version: 5.8.3
+      vitest:
+        specifier: ^4.0.18
+        version: 4.0.18(jiti@1.21.7)(jsdom@28.1.0)(lightningcss@1.32.0)(terser@5.46.0)(yaml@2.9.0)
 
   packages/ui:
     dependencies:


### PR DESCRIPTION
…inding

Server-defined GenUI components from a mekik backend now render and are observable through <ChativaWebView>:

- Fix the duplicated-core-singletons bug: the bootstrap bound EventBus/ chatStore from a separately loaded chativa-core.global.js while the widget used its own bundled copy, so every callback (onMessage, onConnect, ...) silently never fired. The bridge now binds window.Chativa.EventBus/chatStore (exported from @chativa/ui >= 0.10) and fails loudly on older ui builds; the redundant core script tag is gone.
- Add mekik as a builtin connector type with a JSON-safe auth spec ({kind: token|cookie}) rebuilt into real TokenAuth/CookieAuth instances inside the WebView; onAuthError is bridged out as auth_error.
- Bridge GenUI observability to RN: genui_components_registered (summaries), genui_stream_started/completed, tool_call_updated, with matching props.
- New inbound commands: send_message, open_widget, close_widget.
- Fix inlineJson crashing on omitted locale/i18n (JSON.stringify(undefined)).
- Add vitest suite (bootstrap string assertions, postMessage, and a type drift guard against @chativa/connector-mekik via tsconfig.compat.json).
- Update README bridge reference + Expo example (USE_MEKIK toggle, GenUI logging, bridge command buttons). Bump ui and rn-webview to 0.10.0.