### PR TITLE
feat(connector-mekik): client tools — declare the page's UI as callable tools (mekik §11)

### DIFF
--- a/docs/connectors/mekik.md
+++ b/docs/connectors/mekik.md
@@ -28,6 +28,9 @@ Schema: [`schemas/connectors/mekik.schema.json`](../../schemas/connectors/mekik.
 | `reconnect` | `true` | Auto-reconnect when the socket drops. Suppressed after an auth rejection. |
 | `reconnectDelay` | `2000` | Milliseconds between reconnect attempts. |
 | `maxReconnectAttempts` | `5` | Give up after this many consecutive failures. Reset on a successful handshake. |
+| `reconnectBackoff` | `"fixed"` | `"fixed"` waits `reconnectDelay` every time; `"exponential"` grows the wait up to `reconnectMaxDelay` with full jitter. |
+| `reconnectMaxDelay` | `30000` | Ceiling for `"exponential"` backoff, in ms. |
+| `routeInUrl` | `false` | Put `conversationId`/`userId` in the connect URL query string for sticky-by-conversation load balancing. |
 | `queueOfflineMessages` | `true` | Hold outgoing messages while the socket is down and flush them on (re)connect. |
 | `userId` | server-minted | Stable user identity. Omit to let the server generate one (announced via `welcome`). |
 | `conversationId` | server-minted | Conversation to resume. Omit to start a new one. |
@@ -35,6 +38,8 @@ Schema: [`schemas/connectors/mekik.schema.json`](../../schemas/connectors/mekik.
 | `auth` | — | How this client authenticates — a `MekikAuthProvider` adapter (`CookieAuth`, `TokenAuth`, or your own). Omit for servers that don't authenticate. See [Authentication](#authentication). |
 | `token` | — | **Deprecated** — shorthand for `auth: new TokenAuth({ token, maxRetries: 0 })`. Still works. |
 | `onAuthError` | — | Called when the server rejects the connection, whichever adapter is in use. |
+| `tools` | — | Client tools this page can execute for the server's model (mekik PROTOCOL.md §11): `{name, description?, parameters?, tags?, mode?, handler}`. See [Client tools](#client-tools). |
+| `allowDynamicTools` | `false` | Unlock `registerTool()` / `unregisterTool()` after construction. Off by default so injected script can't rewire the toolset. |
 
 ## Frame mapping
 
@@ -42,7 +47,7 @@ Every mekik transport carries the same JSON frames. The connector routes them li
 
 | mekik frame | Direction | Becomes |
 |---|---|---|
-| `hello` | client → server | Sent on open — `userId` / `conversationId` / `watermark` / `token`. All fields optional. |
+| `hello` | client → server | Sent on open — `userId` / `conversationId` / `watermark` / `token` / `componentsHash` / `tools` (client tool definitions, handlers stay local). All fields optional. |
 | `welcome` | server → client | Identity + current watermark. Captured on `connector.identity`, never rendered as a message. |
 | `text` (bot) | server → client | `text` message bubble. |
 | `text` + `actions` | server → client | `quick-reply` message — chips render natively; tapping one answers the bot. |
@@ -51,6 +56,10 @@ Every mekik transport carries the same JSON frames. The connector routes them li
 | `run` `{ status }` | server → client | Typing indicator: `started` → on, `finished` → off. |
 | `genui` | server → client | `onGenUIChunk` — mounts a GenUI component inline. |
 | `genui_event` | client → server | Sent when a mounted GenUI component fires an event (form submit, card action…). |
+| `interrupt` `{ data.tool }` | server → client | A [client tool](#client-tools) invocation — the registered handler runs and the result goes back as a `resume` with `{ok, result?\|error?}`. Renders nothing. |
+| `interrupt` / `interrupt_resolved` | server → client | Human-in-the-loop pause / its close — chips, a mounted form, or a widget-answered wait. |
+| `genui` event chunk `client_tool` | server → client | A fire-and-forget (`mode: "notify"`) tool invocation — routed to the tool registry, never to mounted components. |
+| `client_tools` | client → server | Sent by `registerTool()` / `unregisterTool()` — replaces this connection's declared toolset. |
 | `error` | server → client | Auth rejection — surfaced via `onAuthError`, followed by close code 4401. |
 | `survey` | client → server | `sendSurvey()` payload. |
 
@@ -257,16 +266,83 @@ connector.receiveComponentEvent("stream-1", "submit", { email: "a@b.com" });
 // → { "type": "genui_event", "streamId": "stream-1", "eventType": "submit", "payload": {...} }
 ```
 
+## Client tools
+
+The page can declare its own capabilities — render one of its UI cards, open a
+native picker, read the device — as **tools** the mekik server's model may call
+(mekik `PROTOCOL.md §11`). The definition travels in the `hello` handshake; the
+handler stays local and runs when the server invokes the tool:
+
+```ts
+const connector = new MekikConnector({
+  url: "wss://bot.example.com/chat",
+  tools: [
+    {
+      name: "pick_date",
+      description: "Open the in-app date picker and let the user choose a date.",
+      parameters: {
+        type: "object",
+        properties: { min: { type: "string", description: "Earliest selectable ISO date" } },
+        required: ["min"],
+      },
+      // Optional: the server only offers this tool to graph nodes that ask for
+      // an intersecting tag; untagged tools are visible to every node.
+      tags: ["scheduling"],
+      handler: async (params) => ({ date: await openDatePicker(params?.min as string) }),
+    },
+    {
+      name: "show_confetti",
+      mode: "notify", // fire-and-forget: arrives as a stream event, result discarded
+      handler: () => fireConfetti(),
+    },
+  ],
+});
+```
+
+How an invocation flows:
+
+- **`"call"` (default)** — the server parks its run on an `interrupt` frame
+  carrying `data.tool = { name, params }`. The connector runs the handler and
+  answers with a `resume` carrying `{ ok: true, result }` — or
+  `{ ok: false, error }` when the handler throws, which makes the server-side
+  `await` throw. Nothing is rendered in the chat for a tool pause. The pause is
+  durable: a still-open call re-announced in `welcome.pending` after a
+  reconnect is executed again, so keep handlers idempotent or cheap. Replayed
+  *historic* interrupts (transcript replay on a fresh tab) are never executed.
+- **`"notify"`** — the invocation arrives as a `genui` event chunk under the
+  reserved name `client_tool`, is routed to the handler (deduped by chunk id
+  within a session), and never reaches the mounted components.
+
+Servers ignore declarations unless they opt in (`MekikOptions.clientTools`) and
+may allowlist which names/tags they accept — a declaration is capability, not
+authority.
+
+### Security: the registry is sealed
+
+Tool definitions and handlers are held in **true-private (`#`) fields** — they
+cannot be read or replaced through the connector instance from the console or
+by injected script. Definitions are deep-cloned and frozen at registration
+(mutating the object you passed changes nothing), and the toolset is fixed at
+construction: `registerTool` / `unregisterTool` throw unless the app opted in
+with `allowDynamicTools: true`:
+
+```ts
+const connector = new MekikConnector({ url, tools, allowDynamicTools: true });
+connector.registerTool({ name: "route_scoped", handler });  // re-announces via a client_tools frame
+connector.unregisterTool("route_scoped");
+connector.clientTools;                                      // frozen definitions, no handlers
+```
+
 ## Offline queue
 
 With `queueOfflineMessages: true` (the default) a send that happens while the socket is down is queued and flushed on the next connect. The promise resolves **only when the payload actually reaches the wire**, so the bubble stays on "sending" instead of being stamped "sent" for a message the server never received.
 
 ## Capabilities
 
-Implemented: `sendMessage`, `onMessage`, `onConnect` / `onDisconnect`, `onTyping`, `onToolCall`, `onGenUIChunk`, `receiveComponentEvent`, `sendSurvey`.
+Implemented: `sendMessage`, `onMessage`, `onConnect` / `onDisconnect`, `onTyping`, `onToolCall`, `onGenUIChunk`, `receiveComponentEvent`, `sendSurvey`, client tools (`tools`, `registerTool` / `unregisterTool` behind `allowDynamicTools`).
 
 Not implemented: `sendFile`, `loadHistory` (watermark replay covers resume instead), `onMessageStatus`, `sendFeedback`, multi-conversation.
 
 ## React Native
 
-The connector runs unmodified inside `@chativa/rn-webview`'s WebView embedding — pass `connector: { type: "mekik", options }` with a JSON-safe `auth` spec (`{ kind: "token", ... }` or `{ kind: "cookie" }`) instead of a live `TokenAuth` / `CookieAuth` instance. See [React Native](../react-native.md).
+The connector runs unmodified inside `@chativa/rn-webview`'s WebView embedding — pass `connector: { type: "mekik", options }` with a JSON-safe `auth` spec (`{ kind: "token", ... }` or `{ kind: "cookie" }`) instead of a live `TokenAuth` / `CookieAuth` instance. `tools` cannot cross the bridge (each entry carries a handler function) — apps needing client tools should host the widget with `@chativa/react` or a `custom` connector script. See [React Native](../react-native.md).

--- a/packages/connector-mekik/src/__tests__/MekikConnector.test.ts
+++ b/packages/connector-mekik/src/__tests__/MekikConnector.test.ts
@@ -868,3 +868,222 @@ describe("MekikConnector server-defined components", () => {
     expect(seen[seen.length - 1]).toEqual([v2]);
   });
 });
+
+describe("MekikConnector client tools (mekik/1 §11)", () => {
+  const flush = () => new Promise((r) => setTimeout(r, 0));
+
+  function makeToolConnector(
+    tools: ConstructorParameters<typeof MekikConnector>[0]["tools"],
+    extra?: Partial<ConstructorParameters<typeof MekikConnector>[0]>,
+  ) {
+    const connector = new MekikConnector({ url: "ws://test", reconnect: false, tools, ...extra });
+    const messages: Array<Record<string, unknown>> = [];
+    const chunks: Array<{ streamId: string; chunk: unknown }> = [];
+    connector.onMessage((m) => messages.push(m as unknown as Record<string, unknown>));
+    connector.onGenUIChunk((streamId, chunk) => chunks.push({ streamId, chunk }));
+    const route = (frame: Record<string, unknown>) =>
+      (connector as unknown as { routeFrame(raw: string): void }).routeFrame(JSON.stringify(frame));
+    const queue = () => (connector as unknown as { queue: Array<{ payload: string }> }).queue;
+    return { connector, messages, chunks, route, queue };
+  }
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    MockWebSocket.instances = [];
+  });
+
+  it("declares the tool definitions (never the handlers) in the hello handshake", async () => {
+    vi.stubGlobal("WebSocket", MockWebSocket);
+    const connector = new MekikConnector({
+      url: "ws://test",
+      reconnect: false,
+      tools: [
+        {
+          name: "pick_date",
+          description: "Open the date picker",
+          parameters: { type: "object", properties: { min: { type: "string" } } },
+          tags: ["scheduling"],
+          handler: () => ({ date: "2026-08-15" }),
+        },
+        { name: "show_confetti", mode: "notify", handler: () => {} },
+      ],
+    });
+    const connecting = connector.connect();
+    MockWebSocket.instances[0].open();
+    await connecting;
+
+    const hello = JSON.parse(MockWebSocket.instances[0].sent[0]) as Record<string, unknown>;
+    expect(hello.type).toBe("hello");
+    expect(hello.tools).toEqual([
+      {
+        name: "pick_date",
+        description: "Open the date picker",
+        parameters: { type: "object", properties: { min: { type: "string" } } },
+        tags: ["scheduling"],
+      },
+      { name: "show_confetti", mode: "notify" },
+    ]);
+    await connector.disconnect();
+  });
+
+  it("executes a live tool interrupt and answers with the {ok:true, result} envelope", async () => {
+    const handler = vi.fn(() => ({ date: "2026-08-15" }));
+    const { messages, route, queue } = makeToolConnector([{ name: "pick_date", handler }]);
+
+    route({
+      type: "interrupt",
+      seq: 5,
+      id: "call:tool:pick_date",
+      data: { payload: {}, tool: { name: "pick_date", params: { min: "2026-08-01" } } },
+    });
+    await flush();
+
+    expect(handler).toHaveBeenCalledWith({ min: "2026-08-01" });
+    expect(messages).toEqual([]); // a tool pause renders nothing — no chips, no form
+    expect(queue()).toHaveLength(1);
+    expect(JSON.parse(queue()[0].payload)).toEqual({
+      type: "resume",
+      answers: { "call:tool:pick_date": { ok: true, result: { date: "2026-08-15" } } },
+    });
+  });
+
+  it("answers {ok:false, error} when the handler throws", async () => {
+    const { route, queue } = makeToolConnector([
+      { name: "pick_date", handler: () => Promise.reject(new Error("picker dismissed")) },
+    ]);
+
+    route({ type: "interrupt", seq: 5, id: "i1", data: { payload: {}, tool: { name: "pick_date" } } });
+    await flush();
+
+    expect(JSON.parse(queue()[0].payload)).toEqual({
+      type: "resume",
+      answers: { i1: { ok: false, error: "picker dismissed" } },
+    });
+  });
+
+  it("leaves a tool pause standing when no handler is registered here", async () => {
+    const { messages, route, queue } = makeToolConnector([]);
+
+    route({ type: "interrupt", seq: 5, id: "i1", data: { payload: {}, tool: { name: "someone_elses" } } });
+    await flush();
+
+    expect(messages).toEqual([]);
+    expect(queue()).toHaveLength(0);
+  });
+
+  it("does not re-execute replayed historic tool interrupts, but does execute welcome.pending ones", async () => {
+    const handler = vi.fn(() => "ok");
+    const { route, queue } = makeToolConnector([{ name: "confirm", handler }]);
+
+    route({
+      type: "welcome",
+      data: {
+        conversationId: "c1",
+        userId: "u1",
+        connectionId: "cx",
+        watermark: 10,
+        pending: [{ id: "open:tool:confirm", data: { payload: {}, tool: { name: "confirm" } } }],
+      },
+    });
+    // A replayed (historic, long-resolved) interrupt: seq ≤ the welcome watermark.
+    route({ type: "interrupt", seq: 7, id: "old:tool:confirm", data: { payload: {}, tool: { name: "confirm" } } });
+    await flush();
+
+    expect(handler).toHaveBeenCalledTimes(1); // the pending one only
+    expect(queue()).toHaveLength(1);
+    expect(JSON.parse(queue()[0].payload).answers).toEqual({ "open:tool:confirm": { ok: true, result: "ok" } });
+  });
+
+  it("executes each tool interrupt at most once per session", async () => {
+    const handler = vi.fn(() => "ok");
+    const { route, queue } = makeToolConnector([{ name: "confirm", handler }]);
+
+    route({ type: "interrupt", seq: 5, id: "i1", data: { payload: {}, tool: { name: "confirm" } } });
+    route({ type: "interrupt", seq: 5, id: "i1", data: { payload: {}, tool: { name: "confirm" } } });
+    await flush();
+
+    expect(handler).toHaveBeenCalledTimes(1);
+    expect(queue()).toHaveLength(1);
+  });
+
+  it("routes a notify client_tool event chunk to the handler, not to the GenUI layer, deduped by chunk id", async () => {
+    const handler = vi.fn();
+    const { chunks, route } = makeToolConnector([{ name: "show_confetti", mode: "notify", handler }]);
+
+    const frame = {
+      type: "genui",
+      seq: 9,
+      streamId: "stream-1",
+      done: false,
+      chunk: { type: "event", name: "client_tool", payload: { name: "show_confetti", params: { level: 3 } }, id: "t0" },
+    };
+    route(frame);
+    route(frame); // replay/duplicate — must not fire twice
+    await flush();
+
+    expect(handler).toHaveBeenCalledTimes(1);
+    expect(handler).toHaveBeenCalledWith({ level: 3 });
+    expect(chunks).toEqual([]); // swallowed: it addresses the tool registry
+
+    // An ordinary event chunk still reaches the GenUI layer untouched.
+    route({
+      type: "genui",
+      seq: 10,
+      streamId: "stream-1",
+      done: false,
+      chunk: { type: "event", name: "highlight", payload: {}, id: 2 },
+    });
+    expect(chunks).toHaveLength(1);
+  });
+
+  it("seals the toolset by default: registerTool/unregisterTool throw", () => {
+    const { connector } = makeToolConnector([{ name: "a", handler: () => {} }]);
+    expect(() => connector.registerTool({ name: "b", handler: () => {} })).toThrow(/sealed/);
+    expect(() => connector.unregisterTool("a")).toThrow(/sealed/);
+    expect(connector.clientTools.map((t) => t.name)).toEqual(["a"]);
+  });
+
+  it("with allowDynamicTools, register/unregister re-announce the full set via a client_tools frame", async () => {
+    vi.stubGlobal("WebSocket", MockWebSocket);
+    const connector = new MekikConnector({
+      url: "ws://test",
+      reconnect: false,
+      allowDynamicTools: true,
+      tools: [{ name: "a", handler: () => {} }],
+    });
+    const connecting = connector.connect();
+    const ws = MockWebSocket.instances[0];
+    ws.open();
+    await connecting;
+
+    connector.registerTool({ name: "b", tags: ["x"], handler: () => {} });
+    let announce = JSON.parse(ws.sent[ws.sent.length - 1]) as Record<string, unknown>;
+    expect(announce.type).toBe("client_tools");
+    expect(announce.tools).toEqual([{ name: "a" }, { name: "b", tags: ["x"] }]);
+
+    connector.unregisterTool("a");
+    announce = JSON.parse(ws.sent[ws.sent.length - 1]) as Record<string, unknown>;
+    expect(announce.tools).toEqual([{ name: "b", tags: ["x"] }]);
+    await connector.disconnect();
+  });
+
+  it("freezes cloned definitions: later mutation of the caller's object changes nothing", () => {
+    const def = { name: "a", tags: ["one"], handler: () => {} };
+    const { connector } = makeToolConnector([def]);
+    def.tags.push("two");
+    (def as { name: string }).name = "renamed";
+
+    expect(connector.clientTools).toEqual([{ name: "a", tags: ["one"] }]);
+    expect(Object.isFrozen(connector.clientTools[0])).toBe(true);
+    expect(Object.isFrozen(connector.clientTools[0].tags)).toBe(true);
+  });
+
+  it("rejects a tool without a name or handler at construction", () => {
+    expect(
+      () => new MekikConnector({ url: "ws://test", tools: [{ name: "", handler: () => {} }] }),
+    ).toThrow(/non-empty name/);
+    expect(
+      () => new MekikConnector({ url: "ws://test", tools: [{ name: "x" } as never] }),
+    ).toThrow(/handler function/);
+  });
+});

--- a/packages/connector-mekik/src/index.ts
+++ b/packages/connector-mekik/src/index.ts
@@ -50,6 +50,58 @@ function interruptText(payload: Record<string, unknown>): string {
   return "Approval required";
 }
 
+/** What a client tool handler receives: the `params` the server-side caller passed. */
+export type MekikClientToolHandler = (
+  params: Record<string, unknown> | undefined,
+) => unknown | Promise<unknown>;
+
+/**
+ * One tool this client declares to the mekik server (mekik PROTOCOL.md §11):
+ * a UI capability — render a card, open a picker, read the device — described
+ * well enough for a server-side model to call it. The definition (everything
+ * but `handler`) travels in the `hello` handshake; the handler stays local and
+ * runs when the server invokes the tool.
+ *
+ * Security note: the definition is deep-cloned and frozen at registration, and
+ * both definitions and handlers live in true-private (`#`) fields — page-level
+ * script cannot reach or rewire them through the connector instance. Servers
+ * additionally opt in and allowlist declarations on their side.
+ */
+export interface MekikClientTool {
+  /** Unique tool name; a redeclared name replaces the earlier one. */
+  name: string;
+  /** What the tool does — this is what the server-side model reads. */
+  description?: string;
+  /** JSON Schema for the tool's parameters (the model's input_schema). */
+  parameters?: Record<string, unknown>;
+  /**
+   * Server-side filter labels (§11.2): the server exposes tagged tools only to
+   * graph nodes that ask for an intersecting tag; untagged tools are
+   * unrestricted.
+   */
+  tags?: string[];
+  /**
+   * `"call"` (default): the server parks its run until {@link handler} answers;
+   * the result (or thrown error) is sent back in a `resume` frame.
+   * `"notify"`: fire-and-forget — the invocation arrives as a stream event and
+   * the handler's return value is discarded.
+   */
+  mode?: "call" | "notify";
+  /** Runs when the server invokes the tool. */
+  handler: MekikClientToolHandler;
+}
+
+/** The wire shape of a declaration — {@link MekikClientTool} minus the handler. */
+type ClientToolDefinition = Omit<MekikClientTool, "handler">;
+
+function deepFreeze<T>(value: T): T {
+  if (typeof value === "object" && value !== null) {
+    for (const v of Object.values(value)) deepFreeze(v);
+    Object.freeze(value);
+  }
+  return value;
+}
+
 export interface MekikConnectorOptions {
   /** mekik WebSocket endpoint, e.g. "ws://localhost:8790/chat". */
   url: string;
@@ -107,6 +159,22 @@ export interface MekikConnectorOptions {
    * provider asks to retry, so this is where an app redirects to login.
    */
   onAuthError?: (error: MekikAuthError) => void;
+  /**
+   * Tools this client can execute on the server's behalf (mekik PROTOCOL.md
+   * §11). Declared in the `hello` handshake; when the server invokes one, the
+   * matching {@link MekikClientTool.handler} runs and its result round-trips
+   * back automatically. Ignored by servers that did not opt in.
+   */
+  tools?: MekikClientTool[];
+  /**
+   * Allow {@link MekikConnector.registerTool} / {@link MekikConnector.unregisterTool}
+   * after construction. **Off by default on purpose**: with the default, the
+   * tool set is fixed at construction and held in true-private fields, so
+   * console access or an injected script cannot add or replace tools at
+   * runtime. Enable only when the app legitimately changes its toolset while
+   * running (e.g. route-scoped tools in a SPA).
+   */
+  allowDynamicTools?: boolean;
 }
 
 /** Identity assigned/confirmed by the server's `welcome` frame. */
@@ -167,12 +235,38 @@ export class MekikConnector implements IConnector {
 
   private ws: WebSocket | null = null;
   private options: Required<
-    Omit<MekikConnectorOptions, "userId" | "conversationId" | "auth" | "token" | "onAuthError">
+    Omit<
+      MekikConnectorOptions,
+      "userId" | "conversationId" | "auth" | "token" | "onAuthError" | "tools" | "allowDynamicTools"
+    >
   > &
     Pick<
       MekikConnectorOptions,
       "userId" | "conversationId" | "auth" | "token" | "onAuthError"
     >;
+
+  // ── client tools (mekik PROTOCOL.md §11) ─────────────────────────────
+  // True-private (#) on purpose: `private` is erased at runtime, so a console
+  // user or injected script could otherwise read or replace tool handlers on
+  // the instance. With #fields the registry is unreachable from outside the
+  // class body, and the definitions are frozen clones — the declaration the
+  // server saw cannot be mutated after the fact.
+  /** Frozen definition clones, in declaration order — what `hello.tools` carries. */
+  #toolDefs: readonly ClientToolDefinition[] = [];
+  /** name → handler; never exposed. */
+  readonly #toolHandlers = new Map<string, MekikClientToolHandler>();
+  /** Locked unless `allowDynamicTools: true` was passed at construction. */
+  readonly #allowDynamicTools: boolean = false;
+  /** Interrupt ids whose tool handler already ran this session (idempotence guard). */
+  readonly #executedToolCalls = new Set<string>();
+  /** `streamId:chunkId` keys of notify invocations already fired this session. */
+  readonly #firedNotifications = new Set<string>();
+  /**
+   * The server's seq at welcome. Replayed history frames carry seq ≤ this, so a
+   * replayed (possibly long-resolved) tool interrupt is never re-executed —
+   * still-open calls are re-announced via `welcome.pending` instead.
+   */
+  #sessionBaseSeq = 0;
 
   /** The `auth` adapter, or one desugared from the legacy `token` option. */
   private readonly authProvider: MekikAuthProvider | undefined;
@@ -232,6 +326,9 @@ export class MekikConnector implements IConnector {
   private generation = 0;
 
   constructor(options: MekikConnectorOptions) {
+    // Tools never land on `this.options` (a soft-private field): the defs and
+    // handlers go straight into the # registry below.
+    const { tools, allowDynamicTools, ...rest } = options;
     this.options = {
       protocols: [],
       reconnect: true,
@@ -242,8 +339,10 @@ export class MekikConnector implements IConnector {
       routeInUrl: false,
       queueOfflineMessages: true,
       resumeConversation: false,
-      ...options,
+      ...rest,
     };
+    this.#allowDynamicTools = allowDynamicTools === true;
+    for (const tool of tools ?? []) this.#storeTool(tool);
     // Captured before `welcome` can adopt a server-minted id: only an
     // app-configured userId scopes the storage key (see storageKey()).
     this.configuredUserId = options.userId;
@@ -271,6 +370,125 @@ export class MekikConnector implements IConnector {
   /** The last auth rejection (null unless the server refused this connection). */
   get authError(): MekikAuthError | null {
     return this._authError;
+  }
+
+  // ── client tools API (mekik PROTOCOL.md §11) ─────────────────────────
+
+  /** The declared tool definitions (frozen; handlers are not exposed). */
+  get clientTools(): readonly Omit<MekikClientTool, "handler">[] {
+    return this.#toolDefs;
+  }
+
+  /**
+   * Declare (or replace) one tool at runtime and re-announce the full set to
+   * the server with a `client_tools` frame. Requires
+   * {@link MekikConnectorOptions.allowDynamicTools} — with the default, the
+   * toolset is sealed at construction so page-level script cannot rewire what
+   * the server-side model may trigger.
+   */
+  registerTool(tool: MekikClientTool): void {
+    this.#assertDynamicToolsAllowed();
+    this.#storeTool(tool);
+    this.#announceTools();
+  }
+
+  /** Withdraw one tool at runtime and re-announce. Same lock as {@link registerTool}. */
+  unregisterTool(name: string): void {
+    this.#assertDynamicToolsAllowed();
+    if (!this.#toolHandlers.delete(name)) return;
+    this.#toolDefs = this.#toolDefs.filter((d) => d.name !== name);
+    this.#announceTools();
+  }
+
+  #assertDynamicToolsAllowed(): void {
+    if (!this.#allowDynamicTools) {
+      throw new Error(
+        "MekikConnector: the toolset is sealed. Pass `allowDynamicTools: true` at construction to change tools at runtime.",
+      );
+    }
+  }
+
+  /** Validate, deep-clone, freeze, and store one tool (last declaration of a name wins). */
+  #storeTool(tool: MekikClientTool): void {
+    if (typeof tool?.name !== "string" || tool.name.length === 0) {
+      throw new Error("MekikConnector: a client tool needs a non-empty name.");
+    }
+    if (typeof tool.handler !== "function") {
+      throw new Error(`MekikConnector: client tool "${tool.name}" needs a handler function.`);
+    }
+    // Clone via JSON so later mutation of the caller's object cannot silently
+    // change what was (or will be) declared to the server.
+    const def = deepFreeze(
+      JSON.parse(
+        JSON.stringify({
+          name: tool.name,
+          ...(tool.description !== undefined ? { description: tool.description } : {}),
+          ...(tool.parameters !== undefined ? { parameters: tool.parameters } : {}),
+          ...(tool.tags !== undefined ? { tags: tool.tags } : {}),
+          ...(tool.mode !== undefined ? { mode: tool.mode } : {}),
+        }),
+      ) as ClientToolDefinition,
+    );
+    const existing = this.#toolDefs.findIndex((d) => d.name === def.name);
+    this.#toolDefs =
+      existing >= 0
+        ? this.#toolDefs.map((d, i) => (i === existing ? def : d))
+        : [...this.#toolDefs, def];
+    this.#toolHandlers.set(def.name, tool.handler);
+  }
+
+  /** Replace the server's view of this connection's toolset (a live socket only — `hello` covers reconnects). */
+  #announceTools(): void {
+    if (this.ws?.readyState === WebSocket.OPEN) {
+      this.ws.send(JSON.stringify({ type: "client_tools", tools: this.#toolDefs }));
+    }
+  }
+
+  /**
+   * Run the handler for a server-invoked tool call and answer the pause with
+   * the §11.3 result envelope. Executed at most once per interrupt id per
+   * session; an id nobody here handles is left standing (another tab may own
+   * it — the pause is durable and re-announced on its reconnect).
+   */
+  async #executeToolCall(id: string, call: { name: string; params?: Record<string, unknown> }): Promise<void> {
+    if (this.#executedToolCalls.has(id)) return;
+    const handler = this.#toolHandlers.get(call.name);
+    if (!handler) return;
+    this.#executedToolCalls.add(id);
+
+    let envelope: Record<string, unknown>;
+    try {
+      const result = await handler(call.params);
+      envelope = { ok: true, ...(result !== undefined ? { result } : {}) };
+    } catch (err) {
+      envelope = { ok: false, error: err instanceof Error ? err.message : String(err) };
+    }
+    this.openInterrupts.delete(id);
+    await this.sendOrQueue(JSON.stringify({ type: "resume", answers: { [id]: envelope } }));
+  }
+
+  /**
+   * A `"notify"`-mode invocation arrives as a stream event chunk under the
+   * reserved name `client_tool` (§11.3). It belongs to the tool registry, not
+   * the mounted components — fire the handler (once per chunk key) and swallow
+   * the chunk. Returns true when the chunk was claimed.
+   */
+  #maybeClientToolChunk(streamId: string, chunk: unknown): boolean {
+    if (!isRecord(chunk) || chunk.type !== "event" || chunk.name !== "client_tool") return false;
+    const payload = isRecord(chunk.payload) ? chunk.payload : {};
+    const name = typeof payload.name === "string" ? payload.name : "";
+    const key = `${streamId}:${String(chunk.id ?? "")}`;
+    if (!name || this.#firedNotifications.has(key)) return true;
+    this.#firedNotifications.add(key);
+    const handler = this.#toolHandlers.get(name);
+    if (handler) {
+      // Fire-and-forget by contract: the result is discarded, a failure is the
+      // client's own business — nothing round-trips.
+      void Promise.resolve()
+        .then(() => handler(isRecord(payload.params) ? payload.params : undefined))
+        .catch(() => {});
+    }
+    return true;
   }
 
   async connect(): Promise<void> {
@@ -442,6 +660,19 @@ export class MekikConnector implements IConnector {
     this.openInterrupts.set(id, { ui: d.ui, actions });
     this.typingHandler?.(false);
 
+    // A client tool call (§11.3): the pause is answered by our registered
+    // handler, not by a human — render nothing. Execute only when the call is
+    // actually open: a `welcome.pending` re-announcement (no seq) or a live
+    // frame (seq beyond the welcome watermark); a replayed historic interrupt
+    // is display-order bookkeeping, not an instruction to run the tool again.
+    if (isRecord(d.tool) && typeof d.tool.name === "string") {
+      const live = frame.seq === undefined || (typeof frame.seq === "number" && frame.seq > this.#sessionBaseSeq);
+      if (live) {
+        void this.#executeToolCall(id, d.tool as { name: string; params?: Record<string, unknown> });
+      }
+      return;
+    }
+
     if (actions && actions.length > 0) {
       // Chips display and send the label; asResume maps it back to the answer.
       this.renderQuickReply(id, interruptText(payload), actions.map((a) => ({ label: a.label, value: a.label })));
@@ -604,6 +835,11 @@ export class MekikConnector implements IConnector {
       }
       if (this.options.resumeConversation) this.saveSession();
 
+      // Frames replayed after this welcome carry seq ≤ the server's current
+      // watermark — that boundary is what keeps historic (already-resolved)
+      // client tool calls from re-executing (§11.3).
+      this.#sessionBaseSeq = this._identity.watermark;
+
       // mekik/2: the server re-announces any open interrupts so a reconnecting
       // tab re-renders the approval it was parked on (§3.2).
       const pending = (data.data as Record<string, unknown> | undefined)?.pending;
@@ -649,6 +885,9 @@ export class MekikConnector implements IConnector {
         this.toolCallHandler?.(frame.toolCall);
         return;
       case "genui":
+        // A reserved `client_tool` event chunk is a notify-mode invocation
+        // (§11.3): it addresses the tool registry, never a mounted component.
+        if (this.#maybeClientToolChunk(frame.streamId, frame.chunk)) return;
         this.genUIChunkHandler?.(frame.streamId, frame.chunk, frame.done);
         return;
       case "genui_components":
@@ -795,6 +1034,9 @@ export class MekikConnector implements IConnector {
         // server answers `unchanged` instead of re-sending the markup.
         ...(componentsHash ? { componentsHash } : {}),
         ...(token ? { token } : {}),
+        // Client tools (§11.1): the definitions only — handlers stay local.
+        // Re-sent on every (re)connect, since declarations are per-connection.
+        ...(this.#toolDefs.length > 0 ? { tools: this.#toolDefs } : {}),
       }),
     );
     this.flushQueue();

--- a/packages/rn-webview/src/bridge/types.ts
+++ b/packages/rn-webview/src/bridge/types.ts
@@ -65,6 +65,11 @@ export interface MekikConnectorSpecOptions {
    * the bridge; prefer `auth: { kind: "token", ... }`.
    */
   token?: string;
+  // `tools` / `allowDynamicTools` (client tools, mekik PROTOCOL.md §11) are
+  // deliberately absent: each tool carries a handler function, which can't
+  // cross the native/web bridge. Apps needing client tools should host the
+  // widget with `@chativa/react` or supply a `custom` connector script that
+  // constructs its own MekikConnector with tools.
 }
 
 /**

--- a/schemas/connectors/mekik.schema.json
+++ b/schemas/connectors/mekik.schema.json
@@ -12,12 +12,17 @@
     "reconnect":            { "type": "boolean", "default": true,  "description": "Auto-reconnect when the socket closes. Suppressed after an auth rejection (close code 4401)." },
     "reconnectDelay":       { "type": "integer", "minimum": 0, "default": 2000, "description": "Milliseconds to wait between reconnect attempts." },
     "maxReconnectAttempts": { "type": "integer", "minimum": 0, "default": 5,    "description": "Stop reconnecting after this many consecutive failures. Reset on a successful handshake." },
+    "reconnectBackoff":     { "type": "string", "enum": ["fixed", "exponential"], "default": "fixed", "description": "Reconnect pacing: \"fixed\" waits reconnectDelay every time; \"exponential\" grows the wait geometrically up to reconnectMaxDelay with full jitter." },
+    "reconnectMaxDelay":    { "type": "integer", "minimum": 0, "default": 30000, "description": "Ceiling for \"exponential\" backoff, in milliseconds." },
+    "routeInUrl":           { "type": "boolean", "default": false, "description": "Put conversationId (and userId) in the connect URL query string so a sticky-by-conversation load balancer can route the upgrade. Off by default (they stay out of URLs / server logs)." },
     "queueOfflineMessages": { "type": "boolean", "default": true,  "description": "Queue outgoing messages while the socket is down and flush them on (re)connect." },
     "userId":               { "type": "string", "description": "Stable user identity sent in the hello handshake. Omit to let the server mint one (announced via the welcome frame). An authenticating server may override this with the verified identity." },
     "conversationId":       { "type": "string", "description": "Conversation to resume. Omit to start a new one." },
     "resumeConversation":   { "type": "boolean", "default": false, "description": "Persist identity + watermark in localStorage and resume across page reloads." },
     "auth":                 { "type": "object", "description": "MekikAuthProvider adapter deciding what credential this client presents (CookieAuth, TokenAuth, or a custom provider). Cannot be serialised — set programmatically. Takes precedence over `token`." },
     "token":                { "type": "string", "description": "Deprecated — shorthand for `auth: new TokenAuth({ token, maxRetries: 0 })`: a credential sent in the hello handshake with no retry on rejection. A function returning a fresh token per attempt is also accepted, but cannot be serialised — set that programmatically. Not needed for cookie-based auth.", "deprecated": true },
-    "onAuthError":          { "type": "object", "description": "Callback invoked when the server rejects the connection (error frame + close code 4401). Cannot be serialised — set programmatically." }
+    "onAuthError":          { "type": "object", "description": "Callback invoked when the server rejects the connection (error frame + close code 4401). Cannot be serialised — set programmatically." },
+    "tools":                { "type": "array", "items": { "type": "object" }, "description": "Client tools declared to the server (mekik PROTOCOL.md §11): {name, description?, parameters?, tags?, mode?, handler}. Each entry carries a handler function, so the option cannot be serialised — set programmatically. Ignored by servers that did not opt in." },
+    "allowDynamicTools":    { "type": "boolean", "default": false, "description": "Allow registerTool()/unregisterTool() after construction. Off by default: with the default the toolset is sealed at construction and held in true-private fields, so injected script cannot rewire what the server-side model may trigger." }
   }
 }


### PR DESCRIPTION
## What

The client half of mekik's new **client tools** (PROTOCOL.md §11, see `AimTune/mekik` PR "feat(protocol): client tools"): the page declares tools (`name`, `description`, JSON-schema `parameters`, `tags`, `mode`, `handler`) to the mekik server; definitions travel in `hello.tools`, handlers stay local and run when the server invokes them.

- Call-mode invocations arrive as an `interrupt` carrying `data.tool` → the handler runs and the result round-trips as a `resume` with the `{ok, result|error}` envelope. Tool pauses render nothing; a pause nobody here handles is left standing for the tab that owns it.
- `welcome.pending` re-announcements re-execute still-open calls; replayed historic interrupts (seq ≤ the welcome watermark) never do, and each interrupt id executes at most once per session.
- Notify-mode invocations arrive as reserved `client_tool` event chunks — routed to the tool registry (deduped by chunk id), never to mounted components.
- **Hardened against page-level tampering**: definitions/handlers live in true-private `#` fields, definitions are deep-cloned + frozen, and the toolset is sealed at construction unless `allowDynamicTools: true` unlocks `registerTool`/`unregisterTool` (which re-announce via a `client_tools` frame).
- Schema sync: adds `tools`/`allowDynamicTools` plus the previously undocumented `reconnectBackoff`/`reconnectMaxDelay`/`routeInUrl`; rn-webview types note `tools` cannot cross the bridge (handlers are functions), like `auth` callbacks.

## Tests

11 new connector tests (53 total green): hello declaration, round-trip + error envelope, no-handler standoff, replay vs pending execution gating, at-most-once, notify routing/dedup, sealed-by-default, dynamic re-announce, frozen clones, constructor validation.

> Stacked on `feature/rn-webview-mekik-genui` so the diff shows only the client-tools work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)