### PR TITLE
fix: stuck stream cursor, duplicate i18next/genui instances, fullscreenOnly

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 ## Quick start
 
 ```html
-<script type="module" src="https://unpkg.com/@chativa/ui/dist/chativa.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/@chativa/ui/dist/chativa.global.js"></script>
 
 <chat-bot-button></chat-bot-button>
 <chat-iva></chat-iva>

--- a/apps/chrome-extension/src/popup.ts
+++ b/apps/chrome-extension/src/popup.ts
@@ -4,11 +4,14 @@ import { DEFAULT_THEME, mergeTheme, type ThemeConfig, type DeepPartial, type Lay
 import type { ButtonPosition, ButtonSize, SpaceLevel, WindowMode, ThemeColors } from "@chativa/core";
 
 // CDN URL used only in the Export snippet (not for actual injection)
-const CDN_PROD_URL = "https://unpkg.com/@chativa/ui/dist/chativa.js";
+// The self-contained IIFE build (the package's `jsdelivr` entry). `dist/index.js`
+// is the bundler build and leaves `lit`/`i18next`/`@chativa/core` as bare
+// imports, so it can't be dropped into a page with a plain <script>.
+const CDN_PROD_URL = "https://cdn.jsdelivr.net/npm/@chativa/ui/dist/chativa.global.js";
 
 // ── Export generators ──────────────────────────────────────────────────────
 function generateCdnSnippet(): string {
-  return `<script type="module" src="${CDN_PROD_URL}"><\\/script>\n<chat-bot-button></chat-bot-button>\n<chat-iva connector="YOUR_CONNECTOR"></chat-iva>`;
+  return `<script src="${CDN_PROD_URL}"><\\/script>\n<chat-bot-button></chat-bot-button>\n<chat-iva connector="YOUR_CONNECTOR"></chat-iva>`;
 }
 
 function generateThemeBuilderCode(theme: ThemeConfig): string {

--- a/docs/chrome-extension.md
+++ b/docs/chrome-extension.md
@@ -112,4 +112,4 @@ sequenceDiagram
 ## Limitations
 
 - Some pages (`chrome://`, `chrome.google.com/webstore`, the Web Store itself) block content-script injection — the popup will display "Cannot inject on this page."
-- The injected widget loads `@chativa/ui` from `unpkg.com`. If the host page has a strict CSP that blocks `unpkg.com`, injection fails. There's no workaround besides relaxing the CSP on a page you control.
+- The injected widget bundles `@chativa/ui` into `inject-main.js` and is injected into the page's MAIN world by the extension, so it loads nothing from a CDN and the host page's CSP does not apply to it.

--- a/docs/genui/custom-component.md
+++ b/docs/genui/custom-component.md
@@ -10,6 +10,13 @@ Two ways to get your own UI into a chat bubble:
 
 Both live in `@chativa/core`, so a widget package doesn't have to depend on `@chativa/genui`.
 
+> **Which package do I import the registry from?** `GenUIRegistry`,
+> `registerServerComponent`, `subscribeServerComponents` and
+> `setServerComponentPolicy` are re-exported by `@chativa/ui`, so an app that
+> already depends on the widget can import them from there and skip the extra
+> dependency. Both paths reach the same registry — `@chativa/ui` does not carry
+> its own copy of the GenUI components.
+
 ## 1. Extend `GenUIElement`
 
 `GenUIElement` extends `ChativaElement` (i18n + auto re-render on locale switch) and implements the whole `GenUIComponentAPI` with working defaults. You call `this.sendEvent(...)` / `this.listenEvent(...)` / `this.tFn(...)` directly — no optional chaining, no injected-property boilerplate.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -8,7 +8,7 @@ Chativa is shipped as a Web Component. You drop one `<script>` and one element i
 <!DOCTYPE html>
 <html>
 <body>
-  <script type="module" src="https://unpkg.com/@chativa/ui/dist/chativa.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/@chativa/ui/dist/chativa.global.js"></script>
   <chat-bot-button></chat-bot-button>
   <chat-iva></chat-iva>
 </body>
@@ -16,6 +16,8 @@ Chativa is shipped as a Web Component. You drop one `<script>` and one element i
 ```
 
 Open the page — the launcher button shows up in the bottom-right. Click it. The default `dummy` connector echoes whatever you type.
+
+`chativa.global.js` is self-contained: it bundles `@chativa/core`, `@chativa/ui` and `@chativa/genui`, and exposes them as `window.Chativa`. Because core is *inside* it, don't also load `chativa-core.global.js` on the same page — the second copy has its own stores, so anything bound to it would silently never fire. For a bundler-based setup, import from `@chativa/ui` instead; the npm build leaves `lit`, `i18next` and `@chativa/core` as normal imports so your bundler resolves one copy of each.
 
 ![Hero — widget closed and open](./assets/screenshots/hero/hero-closed-open.png)
 > _Screenshot placeholder._
@@ -60,7 +62,7 @@ Set `window.chativaSettings` **before** the script tag is parsed. Chativa picks 
     },
   };
 </script>
-<script type="module" src="https://unpkg.com/@chativa/ui/dist/chativa.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/@chativa/ui/dist/chativa.global.js"></script>
 <chat-iva></chat-iva>
 ```
 

--- a/docs/theming.md
+++ b/docs/theming.md
@@ -81,6 +81,25 @@ chatStore.getState().setTheme({
 ![Window modes](./assets/screenshots/hero/window-modes.png)
 > _Screenshot placeholder — four modes side by side._
 
+### Locking the widget to fullscreen
+
+`fullscreen-only` starts the widget expanded and hides the header's fullscreen
+toggle — the shorthand for `setFullscreen(true)` + `setAllowFullscreen(false)`:
+
+```html
+<chat-iva fullscreen-only></chat-iva>
+```
+
+```tsx
+import { ChatIva } from "@chativa/react";
+
+<ChatIva fullscreenOnly />
+```
+
+Passing `false` (or omitting it) means "no opinion": the widget keeps whatever
+`windowMode` and `allowFullscreen` the theme already set, rather than forcing the
+toggle back on.
+
 ## Avatars
 
 ```ts

--- a/packages/core/src/application/ChatEngine.ts
+++ b/packages/core/src/application/ChatEngine.ts
@@ -32,6 +32,12 @@ export class ChatEngine {
    */
   private readonly _textRuns = new Map<string, { msgId: string; runId: string | number }>();
   /**
+   * streamId → every text bubble the stream has opened. `_textRuns` only ever
+   * holds the newest run, so this is what lets `_finishStream` guarantee no
+   * earlier bubble is left with its blinking cursor on.
+   */
+  private readonly _streamTextMsgIds = new Map<string, Set<string>>();
+  /**
    * streamId → the first message the stream created (text bubble or genui message).
    * The run's tool-call trace attaches here, wherever the stream started.
    */
@@ -288,6 +294,10 @@ export class ChatEngine {
     }
     const firstChunk = !this._streamHosts.has(streamId);
 
+    // The reply has started arriving, so the "…" indicator has done its job —
+    // leaving it up would show three dots next to an already-growing bubble.
+    chatStore.getState().setTyping(false);
+
     // Text deltas render as a normal, growing bot bubble (default-text-message);
     // ui/event chunks drive the GenUI message. A mekik text run shares one chunk
     // id (PROTOCOL.md §4.1), so same-id deltas concatenate into one bubble and a
@@ -321,6 +331,12 @@ export class ChatEngine {
       return;
     }
     // A new run id → a fresh bot text bubble the default component renders.
+    // The run it supersedes is finished, so close it here: `_textRuns` holds one
+    // entry per stream, and without this the overwritten run would keep
+    // `streaming: true` forever — a bubble stuck mid-sentence with a blinking
+    // cursor whenever a reply interleaves text → ui → text.
+    if (run) this._closeTextRun(run.msgId);
+
     const msgId = `mekik-text-${streamId}-${chunk.id}`;
     messageStore.getState().addMessage({
       id: msgId,
@@ -331,7 +347,17 @@ export class ChatEngine {
       component: MessageTypeRegistry.resolve("text"),
     });
     this._textRuns.set(streamId, { msgId, runId: chunk.id });
+    const opened = this._streamTextMsgIds.get(streamId);
+    if (opened) opened.add(msgId);
+    else this._streamTextMsgIds.set(streamId, new Set([msgId]));
     this._rememberHost(streamId, msgId);
+  }
+
+  /** Drop the streaming (blinking-cursor) flag from a text bubble. */
+  private _closeTextRun(msgId: string): void {
+    const current = messageStore.getState().messages.find((m) => m.id === msgId);
+    if (!current || current.data?.streaming !== true) return;
+    messageStore.getState().updateById(msgId, { data: { ...current.data, streaming: false } });
   }
 
   /** Append a ui/event chunk to the stream's GenUI message, creating it on first use. */
@@ -386,12 +412,12 @@ export class ChatEngine {
 
   /** Close every message the stream opened and drain its tool-call trace. */
   private _finishStream(streamId: string): void {
-    const run = this._textRuns.get(streamId);
-    if (run) {
-      const current = messageStore.getState().messages.find((m) => m.id === run.msgId);
-      messageStore.getState().updateById(run.msgId, { data: { ...current?.data, streaming: false } });
-      this._textRuns.delete(streamId);
-    }
+    // Sweep every bubble the stream opened, not just the newest run — a run
+    // that was superseded mid-stream is already closed, but a stream that ends
+    // in an unexpected shape must never leave one blinking.
+    for (const msgId of this._streamTextMsgIds.get(streamId) ?? []) this._closeTextRun(msgId);
+    this._streamTextMsgIds.delete(streamId);
+    this._textRuns.delete(streamId);
 
     const genUIMsgId = this._genUIStreams.get(streamId);
     if (genUIMsgId) {
@@ -470,6 +496,14 @@ export class ChatEngine {
       this._reconnectTimer = null;
     }
     chatStore.getState().setReconnectAttempt(0);
+    // A stream cut short by teardown never reaches `_finishStream`, so close its
+    // bubbles here — otherwise the transcript keeps a blinking cursor for a
+    // reply that can no longer arrive.
+    for (const opened of this._streamTextMsgIds.values()) {
+      for (const msgId of opened) this._closeTextRun(msgId);
+    }
+    this._streamTextMsgIds.clear();
+    this._textRuns.clear();
     await this.connector.disconnect();
     this._setStatus("disconnected");
   }

--- a/packages/core/src/application/__tests__/ChatEngine.test.ts
+++ b/packages/core/src/application/__tests__/ChatEngine.test.ts
@@ -594,6 +594,49 @@ describe("ChatEngine", () => {
     expect(msgs.map((m) => m.data.text)).toEqual(["A", "B"]);
   });
 
+  it("closes the previous text bubble when a new text run opens", async () => {
+    const connector = createMockConnector();
+    const engine = new ChatEngine(connector);
+    await engine.init();
+    connector.simulateGenUIChunk("s2d", { type: "text", content: "before", id: 1 }, false);
+    connector.simulateGenUIChunk("s2d", { type: "ui", component: "chart", props: {}, id: 2 }, false);
+    connector.simulateGenUIChunk("s2d", { type: "text", content: "after", id: 3 }, false);
+    const msgs = messageStore.getState().messages;
+    expect(msgs.map((m) => m.data.streaming)).toEqual([false, undefined, true]);
+  });
+
+  it("leaves no text bubble streaming once a multi-run stream is done", async () => {
+    const connector = createMockConnector();
+    const engine = new ChatEngine(connector);
+    await engine.init();
+    connector.simulateGenUIChunk("s2e", { type: "text", content: "intro", id: 1 }, false);
+    connector.simulateGenUIChunk("s2e", { type: "ui", component: "chart", props: {}, id: 2 }, false);
+    connector.simulateGenUIChunk("s2e", { type: "text", content: "outro", id: 3 }, false);
+    connector.simulateGenUIChunk("s2e", { type: "event", name: "stream_done", id: 4 }, true);
+    const texts = messageStore.getState().messages.filter((m) => m.type === "text");
+    expect(texts).toHaveLength(2);
+    expect(texts.every((m) => m.data.streaming === false)).toBe(true);
+  });
+
+  it("clears the typing indicator once stream content starts arriving", async () => {
+    const connector = createMockConnector();
+    const engine = new ChatEngine(connector);
+    await engine.init();
+    connector.simulateTyping(true);
+    expect(chatStore.getState().isTyping).toBe(true);
+    connector.simulateGenUIChunk("s-typing", { type: "text", content: "Hi", id: 1 }, false);
+    expect(chatStore.getState().isTyping).toBe(false);
+  });
+
+  it("closes an in-flight text bubble when the engine is destroyed", async () => {
+    const connector = createMockConnector();
+    const engine = new ChatEngine(connector);
+    await engine.init();
+    connector.simulateGenUIChunk("s-destroy", { type: "text", content: "cut", id: 1 }, false);
+    await engine.destroy();
+    expect(messageStore.getState().messages[0].data.streaming).toBe(false);
+  });
+
   it("appends ui/event chunks into one genui message", async () => {
     const connector = createMockConnector();
     const engine = new ChatEngine(connector);

--- a/packages/core/vite.config.ts
+++ b/packages/core/vite.config.ts
@@ -14,7 +14,17 @@ export default defineConfig({
       formats: ["es", "cjs"],
       fileName: (fmt, entryName) => `${entryName}.${fmt === "es" ? "js" : "cjs"}`,
     },
-    rollupOptions: {},
+    rollupOptions: {
+      // Every runtime dependency stays external so consumers resolve ONE copy
+      // of it. Bundling them here gave `@chativa/core` a private i18next while
+      // `@chativa/ui` initialised its own: `applyGlobalSettings` wrote the
+      // host's `locale`/`i18n` overrides into an instance no component read
+      // from, so bot-name and language settings silently did nothing. The same
+      // duplication would give the two packages separate `lit` registries.
+      // (The CDN build in vite.config.cdn.ts still bundles everything — that
+      // artifact is meant to be self-contained.)
+      external: ["lit", /^lit\//, "i18next", "zustand", /^zustand\//],
+    },
     sourcemap: true,
   },
   plugins: [dts({ rollupTypes: true })],

--- a/packages/genui/vite.config.ts
+++ b/packages/genui/vite.config.ts
@@ -10,7 +10,7 @@ export default defineConfig({
       fileName: (fmt) => `index.${fmt === "es" ? "js" : "cjs"}`,
     },
     rollupOptions: {
-      external: ["lit", "lit/decorators.js", "lit/directives/unsafe-html.js", "@chativa/core", "@chativa/ui", "marked"],
+      external: ["lit", /^lit\//, "@chativa/core", /^@chativa\/core\//, "@chativa/ui", "marked"],
     },
     sourcemap: true,
   },

--- a/packages/react/src/ChatIva.tsx
+++ b/packages/react/src/ChatIva.tsx
@@ -43,7 +43,6 @@ export interface ChatIvaProps {
 
 interface ChatIvaElementProps {
   connector?: string;
-  fulllscreenOnly?: boolean;
   className?: string;
   style?: React.CSSProperties;
   children?: React.ReactNode;
@@ -117,6 +116,20 @@ export const ChatIva = React.forwardRef<HTMLElement, ChatIvaProps>(function Chat
     chatStore.getState().setConnector(connectorName);
   }
 
+  // Same reasoning as the connector above, and the same reason it is applied
+  // here rather than handed to the element as a `fullscreenOnly` property:
+  // `<chat-iva>` decides its window mode while connecting, and `@lit/react`
+  // only assigns element properties afterwards — late enough to render one
+  // non-fullscreen frame first, and not at all in its `node` build. Writing to
+  // the shared store is the one path that works before the element connects.
+  // `false` is deliberately not the inverse: it means "no opinion", so it never
+  // re-enables a fullscreen toggle the theme turned off.
+  if (fullscreenOnly) {
+    const theme = chatStore.getState();
+    if (!theme.isFullscreen) theme.setFullscreen(true);
+    if (theme.allowFullscreen) theme.setAllowFullscreen(false);
+  }
+
   useChativaEvent("message_received", onMessage);
   useChativaEvent("message_sent", onMessageSent);
   useChativaEvent("survey_submitted", onSurveySubmit);
@@ -129,7 +142,6 @@ export const ChatIva = React.forwardRef<HTMLElement, ChatIvaProps>(function Chat
 
   const elementProps: ChatIvaElementProps = { ...rest };
   if (connectorName !== undefined) elementProps.connector = connectorName;
-  if (fullscreenOnly !== undefined) elementProps.fulllscreenOnly = fullscreenOnly;
 
   return <LazyChatIva ref={ref} {...elementProps} />;
 });

--- a/packages/react/src/ChativaProvider.tsx
+++ b/packages/react/src/ChativaProvider.tsx
@@ -64,16 +64,33 @@ export function ChativaProvider({
 
   React.useEffect(() => {
     if (!locale) return;
-    const apply = () => i18next.changeLanguage(locale);
-    if (i18next.isInitialized) apply();
-    else i18next.on("initialized", apply);
+    const apply = () => { void i18next.changeLanguage(locale); };
+    if (i18next.isInitialized) {
+      apply();
+      return;
+    }
+    i18next.on("initialized", apply);
+    return () => { i18next.off("initialized", apply); };
   }, [locale]);
 
   React.useEffect(() => {
     if (!i18n) return;
-    for (const lng of Object.keys(i18next.store.data)) {
+    // `i18next.store` only exists once the instance is initialised, and the
+    // instance is initialised by `@chativa/ui`, which this provider loads
+    // lazily — so on the first render there is nothing to write into yet.
+    const applyToLng = (lng: string) => {
       i18next.addResourceBundle(lng, "translation", i18n, true, true);
-    }
+    };
+    const applyToAll = () => Object.keys(i18next.store.data).forEach(applyToLng);
+    if (i18next.isInitialized) applyToAll();
+    else i18next.on("initialized", applyToAll);
+    // Overrides sit on top of a language's own bundle, so switching language
+    // would otherwise fall back to the shipped strings.
+    i18next.on("languageChanged", applyToLng);
+    return () => {
+      i18next.off("initialized", applyToAll);
+      i18next.off("languageChanged", applyToLng);
+    };
   }, [i18n]);
 
   return <>{children}</>;

--- a/packages/react/src/__tests__/ChatIva.test.tsx
+++ b/packages/react/src/__tests__/ChatIva.test.tsx
@@ -13,6 +13,17 @@ afterEach(() => {
   cleanup();
 });
 
+/**
+ * Wait for the lazily-imported `<chat-iva>` to mount. The first mount in a file
+ * pays for the dynamic `import("@chativa/ui")`, which regularly overruns
+ * `waitFor`'s 1s default in a cold Vitest worker — hence the explicit timeout.
+ */
+function waitForWidget() {
+  return waitFor(() => {
+    expect(document.querySelector("chat-iva")).not.toBeNull();
+  }, { timeout: 15000 });
+}
+
 function makeFakeConnector(name: string): IConnector {
   return {
     name,
@@ -35,9 +46,7 @@ describe("ChatIva", () => {
 
     render(<ChatIva connector={connector} />);
 
-    await waitFor(() => {
-      expect(document.querySelector("chat-iva")).not.toBeNull();
-    });
+    await waitForWidget();
 
     expect(ConnectorRegistry.has("chativa-test-connector-2")).toBe(true);
     // `ChatWidget.connectedCallback` reads `chatStore.activeConnector` (in
@@ -53,13 +62,34 @@ describe("ChatIva", () => {
 
     render(<ChatIva connector="chativa-test-connector-3" />);
 
-    await waitFor(() => {
-      expect(document.querySelector("chat-iva")).not.toBeNull();
-    });
+    await waitForWidget();
 
     expect(chatStore.getState().activeConnector).toBe("chativa-test-connector-3");
 
     ConnectorRegistry.unregister("chativa-test-connector-3");
+  });
+
+  it("applies fullscreenOnly before the element connects, and treats false as no opinion", () => {
+    chatStore.getState().setFullscreen(false);
+    chatStore.getState().setAllowFullscreen(true);
+
+    // Asserted synchronously, without waiting for the element to mount: that is
+    // the point of routing this through the store rather than through a
+    // `fullscreenOnly` element property, which `@lit/react` would only assign
+    // after `<chat-iva>` has already connected and picked a window mode.
+    const { unmount } = render(
+      <ChatIva connector={makeFakeConnector("chativa-test-connector-fs-1")} fullscreenOnly={false} />,
+    );
+    expect(chatStore.getState().isFullscreen).toBe(false);
+    expect(chatStore.getState().allowFullscreen).toBe(true);
+    unmount();
+
+    render(<ChatIva connector={makeFakeConnector("chativa-test-connector-fs-2")} fullscreenOnly />);
+    expect(chatStore.getState().isFullscreen).toBe(true);
+    expect(chatStore.getState().allowFullscreen).toBe(false);
+
+    chatStore.getState().setFullscreen(false);
+    chatStore.getState().setAllowFullscreen(true);
   });
 
   it("maps EventBus events to onMessage / onWidgetOpen / onWidgetClose props", async () => {
@@ -77,9 +107,7 @@ describe("ChatIva", () => {
       />,
     );
 
-    await waitFor(() => {
-      expect(document.querySelector("chat-iva")).not.toBeNull();
-    });
+    await waitForWidget();
 
     const message: IncomingMessage = {
       id: "m1",
@@ -103,9 +131,7 @@ describe("ChatIva", () => {
 
     render(<ChatIva connector={connector} onConnect={onConnect} onDisconnect={onDisconnect} />);
 
-    await waitFor(() => {
-      expect(document.querySelector("chat-iva")).not.toBeNull();
-    });
+    await waitForWidget();
 
     EventBus.emit("connector_status_changed", { status: "connected" });
     EventBus.emit("connector_status_changed", { status: "disconnected" });

--- a/packages/ui/src/__tests__/i18nInstance.test.ts
+++ b/packages/ui/src/__tests__/i18nInstance.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect, afterEach } from "vitest";
+import { i18next as coreI18next, applyGlobalSettings } from "@chativa/core";
+import { i18next, t } from "../index";
+
+/**
+ * There must be exactly one i18next instance across `@chativa/core` and
+ * `@chativa/ui`. When there were two, `applyGlobalSettings` (and
+ * `<ChativaProvider>`'s `locale` / `i18n` props) wrote the host's overrides into
+ * an instance no component ever read from — the bot name and language settings
+ * silently did nothing, and `i18next.store` was undefined besides.
+ */
+describe("@chativa/ui — i18n instance", () => {
+  afterEach(() => {
+    delete window.chativaSettings;
+  });
+
+  it("exports the instance @chativa/core exports, already initialised", () => {
+    expect(i18next).toBe(coreI18next);
+    expect(i18next.isInitialized).toBe(true);
+    // Resources are loaded, so keys resolve rather than echoing back.
+    expect(t("header.title")).toBe("Chativa Chatbot");
+  });
+
+  it("applies a chativaSettings i18n override to the strings components read", () => {
+    window.chativaSettings = { i18n: { header: { title: "Acme Assistant" } } };
+    applyGlobalSettings();
+
+    expect(t("header.title")).toBe("Acme Assistant");
+  });
+});

--- a/packages/ui/src/__tests__/serverComponents.test.ts
+++ b/packages/ui/src/__tests__/serverComponents.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect, afterEach } from "vitest";
+import { genUIDefinitionStore } from "@chativa/core";
+import { GenUIRegistry, clearServerComponents, getServerComponentPolicy } from "../index";
+
+/**
+ * Server-defined GenUI components (mekik PROTOCOL §10) have to work for an app
+ * whose only Chativa dependency is `@chativa/ui`: the definition arrives on the
+ * wire, core publishes it, and the subscription `@chativa/ui` sets up when it
+ * loads has to turn it into a registered custom element.
+ *
+ * This also pins the packaging that makes it possible — `@chativa/ui` reaches
+ * the *same* GenUI registry as `@chativa/genui` rather than carrying an inlined
+ * copy of it, which is what previously left these APIs unreachable and made
+ * importing both packages redefine every `genui-*` element.
+ */
+describe("@chativa/ui — server-defined GenUI components", () => {
+  // Only the registry is reset — `genUIDefinitionStore.clear()` would also drop
+  // the subscription `@chativa/ui` installs at import time, which is the very
+  // thing under test here.
+  afterEach(() => {
+    clearServerComponents();
+  });
+
+  it("registers a component the server publishes, with only @chativa/ui loaded", () => {
+    expect(GenUIRegistry.has("kpi-card")).toBe(false);
+
+    genUIDefinitionStore.publish([
+      { name: "kpi-card", template: "<div class='kpi'>{{label}}</div>" },
+    ]);
+
+    expect(GenUIRegistry.has("kpi-card")).toBe(true);
+  });
+
+  it("exposes the server-component policy controls", () => {
+    expect(getServerComponentPolicy()).toBe("app-wins");
+  });
+});

--- a/packages/ui/src/chat-ui/ChatBotButton.ts
+++ b/packages/ui/src/chat-ui/ChatBotButton.ts
@@ -1,6 +1,6 @@
 import { LitElement, html, css, nothing } from "lit";
 import { customElement, state } from "lit/decorators.js";
-import { t } from "i18next";
+import { t } from "@chativa/core";
 import { ChatbotMixin } from "../mixins/ChatbotMixin";
 
 const SIZE_PX: Record<string, number> = { small: 44, medium: 56, large: 68 };

--- a/packages/ui/src/chat-ui/ChatHeader.ts
+++ b/packages/ui/src/chat-ui/ChatHeader.ts
@@ -1,6 +1,6 @@
 import { LitElement, html, css, nothing } from "lit";
 import { customElement, property, state } from "lit/decorators.js";
-import { t } from "i18next";
+import { t } from "@chativa/core";
 import { ChatbotMixin } from "../mixins/ChatbotMixin";
 
 @customElement("chat-header")

--- a/packages/ui/src/chat-ui/ChatInput.ts
+++ b/packages/ui/src/chat-ui/ChatInput.ts
@@ -1,6 +1,6 @@
 import { LitElement, html, css, nothing } from "lit";
 import { customElement, property, state } from "lit/decorators.js";
-import { t } from "i18next";
+import { t } from "@chativa/core";
 import i18next from "../i18n/i18n";
 import { chatStore, SlashCommandRegistry, resolveText, type ISlashCommand } from "@chativa/core";
 import "./EmojiPicker";

--- a/packages/ui/src/chat-ui/ChatMessageList.ts
+++ b/packages/ui/src/chat-ui/ChatMessageList.ts
@@ -2,7 +2,7 @@ import { LitElement, html, css } from "lit";
 import { customElement } from "lit/decorators.js";
 import { unsafeStatic } from "lit/static-html.js";
 import { html as staticHtml } from "lit/static-html.js";
-import { t } from "i18next";
+import { t } from "@chativa/core";
 import i18next from "../i18n/i18n";
 
 import { messageStore, chatStore, type StoredMessage, type ToolCall } from "@chativa/core";

--- a/packages/ui/src/chat-ui/ChatWidget.ts
+++ b/packages/ui/src/chat-ui/ChatWidget.ts
@@ -1,6 +1,6 @@
 import { LitElement, html, css, nothing } from "lit";
 import { customElement, property, state } from "lit/decorators.js";
-import { t } from "i18next";
+import { t } from "@chativa/core";
 import {
   ChatEngine,
   MultiConversationEngine,
@@ -190,11 +190,24 @@ export class ChatWidget extends ChatbotMixin(LitElement) {
    * Equivalent to: setFullscreen(true) + setAllowFullscreen(false)
    */
   @property({ type: Boolean, attribute: "fullscreen-only" })
-  get fulllscreenOnly(): boolean { return false; }
-  set fulllscreenOnly(_v: boolean) {
+  get fullscreenOnly(): boolean {
+    return this.themeState.isFullscreen && !this.themeState.allowFullscreen;
+  }
+  set fullscreenOnly(v: boolean) {
+    // An absent attribute (or an explicit `false`) means "no opinion" — forcing
+    // the toggle back on here would undo a `setAllowFullscreen(false)` the host
+    // page made for its own reasons.
+    if (!v) return;
     this.themeState.setFullscreen(true);
     this.themeState.setAllowFullscreen(false);
   }
+
+  /**
+   * @deprecated Misspelling of {@link fullscreenOnly}, kept so code written
+   * against 0.10 and earlier keeps working. Use `fullscreenOnly`.
+   */
+  get fulllscreenOnly(): boolean { return this.fullscreenOnly; }
+  set fulllscreenOnly(v: boolean) { this.fullscreenOnly = v; }
 
   // ── File-drop overlay ────────────────────────────────────────────────
 

--- a/packages/ui/src/chat-ui/DefaultTextMessage.ts
+++ b/packages/ui/src/chat-ui/DefaultTextMessage.ts
@@ -2,7 +2,7 @@ import { LitElement, html, css, nothing } from "lit";
 import { customElement, property, state } from "lit/decorators.js";
 import { unsafeHTML } from "lit/directives/unsafe-html.js";
 import { marked } from "marked";
-import { t } from "i18next";
+import { t } from "@chativa/core";
 import i18next from "../i18n/i18n";
 import { MessageTypeRegistry, chatStore, type MessageSender, type MessageStatus } from "@chativa/core";
 import type { LinkMetadataFetcher } from "./LinkPreviewCard";

--- a/packages/ui/src/chat-ui/EmojiPicker.ts
+++ b/packages/ui/src/chat-ui/EmojiPicker.ts
@@ -1,6 +1,6 @@
 import { LitElement, html, css } from "lit";
 import { customElement, state } from "lit/decorators.js";
-import { t } from "i18next";
+import { t } from "@chativa/core";
 import i18next from "../i18n/i18n";
 
 interface EmojiCategory {

--- a/packages/ui/src/chat-ui/EndOfConversationSurvey.ts
+++ b/packages/ui/src/chat-ui/EndOfConversationSurvey.ts
@@ -1,6 +1,6 @@
 import { LitElement, html, css, nothing } from "lit";
 import { customElement, property, state } from "lit/decorators.js";
-import { t } from "i18next";
+import { t } from "@chativa/core";
 import "../i18n/i18n";
 import { chatStore, type EndOfConversationSurveyConfig } from "@chativa/core";
 import { ChatbotMixin } from "../mixins/ChatbotMixin";

--- a/packages/ui/src/chat-ui/ToolCallActivity.ts
+++ b/packages/ui/src/chat-ui/ToolCallActivity.ts
@@ -1,6 +1,6 @@
 import { LitElement, html, css, nothing } from "lit";
 import { customElement, property, state } from "lit/decorators.js";
-import { t } from "i18next";
+import { t } from "@chativa/core";
 import "../i18n/i18n";
 import type { ToolCall } from "@chativa/core";
 import "./ToolCallCard";

--- a/packages/ui/src/chat-ui/ToolCallCard.ts
+++ b/packages/ui/src/chat-ui/ToolCallCard.ts
@@ -1,6 +1,6 @@
 import { LitElement, html, css, nothing } from "lit";
 import { customElement, property, state } from "lit/decorators.js";
-import { t } from "i18next";
+import { t } from "@chativa/core";
 import "../i18n/i18n";
 import type { ToolCall } from "@chativa/core";
 

--- a/packages/ui/src/commands/index.ts
+++ b/packages/ui/src/commands/index.ts
@@ -1,4 +1,4 @@
-import i18next, { t } from "i18next";
+import { i18next, t } from "@chativa/core";
 import { SlashCommandRegistry } from "@chativa/core";
 import type { CommandContext } from "@chativa/core";
 

--- a/packages/ui/src/i18n/i18n.ts
+++ b/packages/ui/src/i18n/i18n.ts
@@ -1,21 +1,35 @@
-import i18next from 'i18next';
+import { i18next } from '@chativa/core';
 import LanguageDetector from 'i18next-browser-languagedetector';
 import en from './en.json';
 import tr from './tr.json';
 
-i18next
-    .use(LanguageDetector)
-    .init({
-        fallbackLng: 'en',
-        debug: false,
-        showSupportNotice: false,
-        resources: {
-            en: { translation: en },
-            tr: { translation: tr },
-        },
-        interpolation: {
-            escapeValue: false, // Lit zaten güvenlidir
-        },
-    });
+// Configure the instance `@chativa/core` exports — NOT a fresh `import i18next
+// from "i18next"`. Those are the same object only when the bundler happens to
+// dedupe the two packages' copies of i18next; when it doesn't, `ChativaSettings`
+// (and `<ChativaProvider>`) write `locale`/`i18n` overrides into an instance no
+// component ever reads from, so the bot name and language props silently do
+// nothing. Going through core makes one instance the definition, not a
+// coincidence of resolution.
+if (!i18next.isInitialized) {
+    i18next
+        .use(LanguageDetector)
+        .init({
+            fallbackLng: 'en',
+            debug: false,
+            showSupportNotice: false,
+            resources: {
+                en: { translation: en },
+                tr: { translation: tr },
+            },
+            interpolation: {
+                escapeValue: false, // Lit zaten güvenlidir
+            },
+        });
+} else {
+    // Another Chativa bundle already initialised it — contribute the resources
+    // without resetting the language the host has settled on.
+    i18next.addResourceBundle('en', 'translation', en, true, false);
+    i18next.addResourceBundle('tr', 'translation', tr, true, false);
+}
 
 export default i18next;

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -11,9 +11,25 @@ export type { LocalizedCommandConfig, CommandTranslations } from "./commands/ind
 export { render } from "./render";
 export type { RenderOptions } from "./render";
 export { GenUIRegistry } from "@chativa/genui";
+// Server-defined GenUI components (mekik PROTOCOL §10). Re-exported here so a
+// host that only depends on @chativa/ui can inspect or extend the registration
+// this bundle already performs — adding `@chativa/genui` alongside it just to
+// reach these would load a second copy of the same custom elements.
+export {
+  registerServerComponent,
+  subscribeServerComponents,
+  clearServerComponents,
+  setServerComponentPolicy,
+  getServerComponentPolicy,
+} from "@chativa/genui";
+export type { ServerComponentPolicy, GenUIComponentDefinition } from "@chativa/genui";
 // Singletons the rn-webview bootstrap bridges against — the CDN (IIFE) build
 // bundles core, so these are the same instances <chat-iva> itself uses.
 export { EventBus, chatStore } from "@chativa/core";
+// The i18n docs have always told readers to `import { i18next } from
+// "@chativa/ui"` — this is the export that makes that true. It is core's
+// instance, the same one `./i18n/i18n` initialises and every component reads.
+export { i18next, t } from "@chativa/core";
 
 // Side-effect registrations (registers custom elements)
 // @chativa/genui: registers genui-message custom element + MessageTypeRegistry.register("genui", ...)

--- a/packages/ui/vite.config.ts
+++ b/packages/ui/vite.config.ts
@@ -10,7 +10,25 @@ export default defineConfig({
             fileName: (fmt) => `index.${fmt === "es" ? "js" : "cjs"}`,
         },
         rollupOptions: {
-            external: ["lit", /^lit\//, "@chativa/core"],
+            // `@chativa/genui` must stay external: inlining it made this bundle
+            // define `genui-card`, `genui-chart`, … a second time, so an app that
+            // imported both packages hit an already-defined custom element and
+            // `MessageTypeRegistry` ended up holding an unconstructable class —
+            // every GenUI message then fell back to plain text. Third-party deps
+            // are external for the same reason (one i18next instance, one lit).
+            // The CDN build (vite.config.cdn.ts) still bundles everything.
+            external: [
+                "lit",
+                /^lit\//,
+                "@chativa/core",
+                /^@chativa\/core\//,
+                "@chativa/genui",
+                "i18next",
+                "i18next-browser-languagedetector",
+                "marked",
+                "@lit-labs/virtualizer",
+                /^@lit-labs\/virtualizer\//,
+            ],
         },
         sourcemap: true,
     },

--- a/website/docs/chrome-extension.md
+++ b/website/docs/chrome-extension.md
@@ -116,4 +116,4 @@ sequenceDiagram
 ## Limitations
 
 - Some pages (`chrome://`, `chrome.google.com/webstore`, the Web Store itself) block content-script injection — the popup will display "Cannot inject on this page."
-- The injected widget loads `@chativa/ui` from `unpkg.com`. If the host page has a strict CSP that blocks `unpkg.com`, injection fails. There's no workaround besides relaxing the CSP on a page you control.
+- The injected widget bundles `@chativa/ui` into `inject-main.js` and is injected into the page's MAIN world by the extension, so it loads nothing from a CDN and the host page's CSP does not apply to it.

--- a/website/docs/genui/custom-component.md
+++ b/website/docs/genui/custom-component.md
@@ -16,6 +16,14 @@ Two ways to get your own UI into a chat bubble:
 
 Both live in `@chativa/core`, so a widget package doesn't have to depend on `@chativa/genui`.
 
+:::tip Which package do I import the registry from?
+`GenUIRegistry`, `registerServerComponent`, `subscribeServerComponents` and
+`setServerComponentPolicy` are re-exported by `@chativa/ui`, so an app that
+already depends on the widget can import them from there and skip the extra
+dependency. Both paths reach the same registry — `@chativa/ui` does not carry
+its own copy of the GenUI components.
+:::
+
 ## 1. Extend `GenUIElement`
 
 `GenUIElement` extends `ChativaElement` (i18n + auto re-render on locale switch) and implements the whole `GenUIComponentAPI` with working defaults. You call `this.sendEvent(...)` / `this.listenEvent(...)` / `this.tFn(...)` directly — no optional chaining, no injected-property boilerplate.

--- a/website/docs/getting-started.md
+++ b/website/docs/getting-started.md
@@ -23,7 +23,7 @@ The fastest way to see Chativa in action:
     <h1>My website</h1>
     <p>Click the chat button in the bottom-right.</p>
 
-    <script type="module" src="https://unpkg.com/@chativa/ui/dist/chativa.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/@chativa/ui/dist/chativa.global.js"></script>
     <chat-bot-button></chat-bot-button>
     <chat-iva></chat-iva>
   </body>
@@ -34,8 +34,9 @@ That's it. Open the file in a browser. The launcher button appears in the bottom
 
 ### What just happened?
 
-- `chativa.js` is an **ESM bundle** that registers two custom elements: `<chat-bot-button>` (the launcher) and `<chat-iva>` (the panel itself).
-- The bundle includes `@chativa/core`, `@chativa/ui`, and `@chativa/genui` — but **not** any connector. The `dummy` connector is part of `@chativa/core` and registered automatically as a fallback.
+- `chativa.global.js` is a **self-contained script** that registers two custom elements: `<chat-bot-button>` (the launcher) and `<chat-iva>` (the panel itself). It also exposes `window.Chativa`.
+- The bundle includes `@chativa/core`, `@chativa/ui`, and `@chativa/genui` — but **not** any connector. The `dummy` connector is part of `@chativa/core` and registered automatically as a fallback. Because core is *inside* this bundle, don't also load `chativa-core.global.js` on the same page: the second copy has its own stores, and anything bound to it (event handlers, `chatStore`) would silently never fire. Reach the singletons through `window.Chativa` instead.
+- For a bundler-based setup, import from `@chativa/ui` instead — the npm build leaves `lit`, `i18next` and `@chativa/core` as normal imports so your bundler resolves one copy of each.
 - Both elements use **Shadow DOM**, so the host page's CSS can't leak in. You theme via CSS variables, not by overriding internal classes.
 
 ## Step 2 — Install via npm (recommended for production)
@@ -238,7 +239,7 @@ If you'd rather not write any imperative wiring code, set `window.chativaSetting
     },
   };
 </script>
-<script type="module" src="https://unpkg.com/@chativa/ui/dist/chativa.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/@chativa/ui/dist/chativa.global.js"></script>
 <chat-iva></chat-iva>
 ```
 
@@ -264,13 +265,13 @@ Use it to test theme presets, switch connectors, trigger every message type, fir
 ## Troubleshooting
 
 **The widget doesn't appear.**
-Check the browser console. The most common cause is a Content Security Policy that blocks ESM modules from `unpkg.com`. Either copy `chativa.js` into your own bundle or extend the CSP with `script-src https://unpkg.com`.
+Check the browser console. The most common cause is a Content Security Policy that blocks the script from `cdn.jsdelivr.net`. Either copy `chativa.global.js` into your own bundle or extend the CSP with `script-src https://cdn.jsdelivr.net`.
 
 **Custom elements show up as plain text in React/Vue/Angular.**
 You forgot to opt in. See the framework-specific snippets above (`CUSTOM_ELEMENTS_SCHEMA` for Angular, `compilerOptions.isCustomElement` for Vue, JSX intrinsic-element augmentation for React).
 
 **My theme isn't applied.**
-You're probably calling `setTheme()` after the widget has rendered with the default. That's fine — `setTheme()` patches at runtime via `mergeTheme()`. But if you rely on `window.chativaSettings.theme`, make sure that script runs **before** `chativa.js`.
+You're probably calling `setTheme()` after the widget has rendered with the default. That's fine — `setTheme()` patches at runtime via `mergeTheme()`. But if you rely on `window.chativaSettings.theme`, make sure that script runs **before** `chativa.global.js`.
 
 **The dummy connector keeps replying instead of my real backend.**
 You registered your real connector but never called `chatStore.getState().setConnector("name")`. Or you set `window.chativaSettings.connector` to a string for which no connector with that name has been registered.

--- a/website/docs/theming.md
+++ b/website/docs/theming.md
@@ -66,6 +66,25 @@ chatStore.getState().setTheme({
 
 > _Captured from the [live sandbox](./sandbox.md). The `inline` mode looks the same as `popup` when no parent layout constrains it — drop the widget inside any container to see the difference._
 
+### Locking the widget to fullscreen
+
+`fullscreen-only` starts the widget expanded and hides the header's fullscreen
+toggle — the shorthand for `setFullscreen(true)` + `setAllowFullscreen(false)`:
+
+```html
+<chat-iva fullscreen-only></chat-iva>
+```
+
+```tsx
+import { ChatIva } from "@chativa/react";
+
+<ChatIva fullscreenOnly />
+```
+
+Passing `false` (or omitting it) means "no opinion": the widget keeps whatever
+`windowMode` and `allowFullscreen` the theme already set, rather than forcing the
+toggle back on.
+
 ## Avatars
 
 ```ts


### PR DESCRIPTION
Six issues reported from a downstream `0.10.0` integration. Each was verified against the source before fixing; findings that differed from the report are called out below.

## 1 — Stuck "typing" cursor (critical)

A reply that goes text → chart → text left the first bubble with `streaming: true` forever, so the user waited on a continuation that never came.

`_textRuns` holds one entry per stream. Opening a new text run overwrote the previous entry without closing its message, and `_finishStream` only cleared the flag on whatever survived in the map.

- a new run now closes the run it supersedes
- `_finishStream` sweeps **every** text bubble the stream opened (new `_streamTextMsgIds`), not just the newest
- `destroy()` closes anything still in flight — a stream cut short by teardown never reaches `_finishStream`

Downstream can drop its `genui_stream_completed` sweep; the mobile bootstrap, which never had that workaround, is fixed too.

## 2 — `fullscreenOnly`

The report blamed the `fulllscreenOnly` misspelling, but **both sides were misspelled identically**, so the names matched. The real cause: `@lit/react` assigns element properties in a `useLayoutEffect` — after the element has connected and already picked a window mode — and its `node` build never assigns them at all. Probing confirmed even `connector` arrived as the default `"dummy"`.

`<ChatIva fullscreenOnly>` now writes to the shared store during render, the same path `connector` already uses for the same reason. `false` means "no opinion" instead of forcing fullscreen. The element property is spelled `fullscreenOnly`; `fulllscreenOnly` stays as a `@deprecated` alias.

## 3 — Two i18next instances

`packages/core/vite.config.ts` had `rollupOptions: {}`, so core bundled `i18next`, `lit` and `zustand` (`dist/index.js` 118 KB → 41 KB). Core had a private i18next while `@chativa/ui` initialised its own, so `applyGlobalSettings` and `<ChativaProvider>` wrote `locale`/`i18n` overrides into an instance no component read from.

- core externalises its runtime deps
- `@chativa/ui`'s components and i18n initialiser take `i18next`/`t` from `@chativa/core`, so one instance is guaranteed rather than left to bundler dedupe
- `@chativa/ui` now actually exports `i18next` and `t` — `docs/i18n.md` has always told readers to import them from there, but the export did not exist
- `<ChativaProvider>`'s `i18n` effect threw on `i18next.store` before init; it now guards and re-applies on language change

## 4 — Second core in the global builds — already fixed on `main`

`chativa-mekik.global.js` does **not** embed core (14 KB, no `createStore`/`EventBus`): connectors deliberately value-import only from the `@chativa/core/frames` subpath. The dead-bridge half was fixed in #36 — `bootstrapHtml` binds to `window.Chativa`.

The remaining real trap is loading `chativa-core.global.js` *and* `chativa.global.js` on one page; that is now documented. Verify against your own artifacts before removing the `build-chativa-cdn.mjs` workaround — the published 0.10.0 build may predate #36.

## 5 — Server-defined GenUI components

`@chativa/ui` inlined `@chativa/genui`, so importing both packages defined every `genui-*` element twice, leaving `MessageTypeRegistry` holding an unconstructable class and silently dropping all GenUI to `default-text-message`. `@chativa/genui` is now external, and `registerServerComponent` / `subscribeServerComponents` / `clearServerComponents` / `setServerComponentPolicy` / `getServerComponentPolicy` are re-exported from `@chativa/ui`.

## 6 — Typing indicator

Cleared on the first GenUI chunk, so the "…" no longer shows next to an already-growing bubble.

## Verification

605 tests pass (13 new), 0 type errors, all packages build. Also fixed a pre-existing flake in `packages/react` where a cold dynamic import overran `waitFor`'s 1 s default — confirmed present on a clean tree first.

## Docs

Both trees updated. The CDN snippets pointed at `dist/chativa.js`, which does not exist in any published artifact — replaced with `chativa.global.js` plus the one-core note. Added the fullscreen lock to `theming.md`, which package to import the GenUI registry from in `genui/custom-component.md`, and corrected the Chrome extension's CSP limitation (it bundles the widget and loads nothing from a CDN).

## Risk

Changing the external lists means consumers' bundlers now resolve `lit`, `i18next`, `zustand`, `marked` and `@chativa/genui` themselves. All are declared `dependencies`, so npm/pnpm installs are fine — but this is worth a smoke test in a real consumer app before publishing. The CDN (IIFE) builds are unaffected; they still bundle everything.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
