### PR TITLE
fix(ui): resolve @chativa/genui from source in tests

### DIFF
--- a/packages/ui/vitest.config.ts
+++ b/packages/ui/vitest.config.ts
@@ -3,8 +3,15 @@ import { resolve } from "path";
 
 export default defineConfig({
   resolve: {
+    // Workspace packages resolve from source so the tests never depend on a
+    // pre-built `dist`. Both entries matter: `package.json` points at `dist`,
+    // so without them a clean checkout that runs tests *before* building — the
+    // release workflow does exactly that — fails to resolve the package at all.
+    // Source also guarantees the tests exercise one shared GenUI registry and
+    // one i18next instance, which is what they are here to pin down.
     alias: {
       "@chativa/core": resolve(__dirname, "../core/src/index.ts"),
+      "@chativa/genui": resolve(__dirname, "../genui/src/index.ts"),
     },
   },
   test: {


### PR DESCRIPTION
Unblocks the `v0.12.0` release, which failed at the **Run tests** step — nothing was published (every publish step was skipped).

The two tests added in #40 for the shared GenUI registry import `../index`, which imports `@chativa/genui`. That package's `package.json` entry points at `dist`.

- **CI** builds before it tests → `dist` exists → green.
- **Release** tests a clean checkout *before* building → `dist` does not exist → `Failed to resolve entry for package "@chativa/genui"`.

Aliasing `@chativa/genui` to source in `packages/ui/vitest.config.ts`, alongside the `@chativa/core` alias already there (and matching what `packages/react` does), makes the tests independent of build artifacts. It also guarantees they exercise one shared registry instead of whatever a stale `dist` happens to hold — which is the whole point of those tests.

Verified by deleting every package `dist` and running the full suite: 605 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
